### PR TITLE
fix: use correct exit status variable for fish shell

### DIFF
--- a/pi-extension/subagents/cmux.ts
+++ b/pi-extension/subagents/cmux.ts
@@ -1,7 +1,24 @@
 import { execSync } from "node:child_process";
+import { basename } from "node:path";
 
 export function isCmuxAvailable(): boolean {
   return !!process.env.CMUX_SOCKET_PATH;
+}
+
+/**
+ * Detect if the user's default shell is fish.
+ * Fish uses $status instead of $? for exit codes.
+ */
+export function isFishShell(): boolean {
+  const shell = process.env.SHELL ?? "";
+  return basename(shell) === "fish";
+}
+
+/**
+ * Return the shell-appropriate exit status variable ($? for bash/zsh, $status for fish).
+ */
+export function exitStatusVar(): string {
+  return isFishShell() ? "$status" : "$?";
 }
 
 export function shellEscape(s: string): string {

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -11,6 +11,7 @@ import {
   pollForExit,
   closeSurface,
   shellEscape,
+  exitStatusVar,
   renameCurrentTab,
   renameWorkspace,
 } from "./cmux.ts";
@@ -234,7 +235,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         parts.push(`@${taskFile}`);
 
         const piCommand = parts.join(" ");
-        const command = `${piCommand}; rm -f ${shellEscape(taskFile)}; echo '__SUBAGENT_DONE_'$?'__'`;
+        const command = `${piCommand}; rm -f ${shellEscape(taskFile)}; echo '__SUBAGENT_DONE_'${exitStatusVar()}'__'`;
 
         // Send to surface
         sendCommand(surface, command);
@@ -650,10 +651,10 @@ export default function subagentsExtension(pi: ExtensionAPI) {
           const msgFile = join(tmpdir(), `subagent-resume-${Date.now()}.md`);
           writeFileSync(msgFile, params.message, "utf8");
           parts.push(`@${msgFile}`);
-          const command = `${parts.join(" ")}; rm -f ${shellEscape(msgFile)}; echo '__SUBAGENT_DONE_'$?'__'`;
+          const command = `${parts.join(" ")}; rm -f ${shellEscape(msgFile)}; echo '__SUBAGENT_DONE_'${exitStatusVar()}'__'`;
           sendCommand(surface, command);
         } else {
-          const command = `${parts.join(" ")}; echo '__SUBAGENT_DONE_'$?'__'`;
+          const command = `${parts.join(" ")}; echo '__SUBAGENT_DONE_'${exitStatusVar()}'__'`;
           sendCommand(surface, command);
         }
 


### PR DESCRIPTION
## Problem

Fish shell uses `$status` instead of `$?` for exit codes. This caused subagent completion detection (`__SUBAGENT_DONE_<code>__`) to fail silently when the user's default shell is fish — the exit code was always empty.

## Solution

- Add `isFishShell()` helper that checks `$SHELL` for fish
- Add `exitStatusVar()` that returns `$status` for fish and `$?` for bash/zsh
- Replace all hardcoded `$?` references in subagent launch and resume commands with `exitStatusVar()`

## Changes

- `pi-extension/subagents/cmux.ts` — new `isFishShell()` and `exitStatusVar()` utilities
- `pi-extension/subagents/index.ts` — use `exitStatusVar()` in 3 places where `$?` was hardcoded