### PR TITLE
Add zellij and tmux support for interactive subagents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # pi-interactive-subagents
 
-Interactive subagents for [pi](https://github.com/badlogic/pi-mono) — spawn, orchestrate, and manage sub-agent sessions in [cmux](https://github.com/manaflow-ai/cmux) terminals.
+Interactive subagents for [pi](https://github.com/badlogic/pi-mono) - spawn, orchestrate, and manage sub-agent sessions in multiplexer panes.
 
 
 https://github.com/user-attachments/assets/c2dafe55-e4a6-4bcc-afac-273e3f05bdca
 
 
-This package gives pi the ability to delegate work to specialized sub-agents that run in their own terminal sessions. A main orchestrator session spawns scouts, planners, workers, and reviewers — each visible in a side-by-side cmux split. The user can watch progress in real-time, interact with interactive agents, and get summaries when autonomous agents finish.
+This package gives pi the ability to delegate work to specialized sub-agents that run in their own terminal sessions. A main orchestrator session spawns scouts, planners, workers, and reviewers, each visible in a side-by-side split. The user can watch progress in real-time, interact with interactive agents, and get summaries when autonomous agents finish.
 
 ## Install
 
@@ -14,20 +14,35 @@ This package gives pi the ability to delegate work to specialized sub-agents tha
 pi install git:github.com/HazAT/pi-interactive-subagents
 ```
 
-> **Requires [cmux](https://github.com/manaflow-ai/cmux).** Start pi inside cmux for subagent support: `cmux pi`
+Supported multiplexers:
+- [cmux](https://github.com/manaflow-ai/cmux)
+- [tmux](https://github.com/tmux/tmux)
+- [zellij](https://zellij.dev)
+
+Start pi inside one of them:
+
+```bash
+cmux pi
+# or
+tmux new -A -s pi 'pi'
+# or
+zellij --session pi   # then run: pi
+```
+
+Optional: set `PI_SUBAGENT_MUX=cmux|tmux|zellij` to force a specific backend.
 
 ## What's Included
 
 ### Extensions
 
-**Subagents** — 5 tools + 3 commands for spawning and managing sub-agents:
+**Subagents** - 5 tools + 3 commands for spawning and managing sub-agents:
 
 | Tool | Description |
 |------|-------------|
-| `subagent` | Spawn a sub-agent in a dedicated cmux terminal |
+| `subagent` | Spawn a sub-agent in a dedicated multiplexer pane |
 | `parallel_subagents` | Run multiple autonomous sub-agents concurrently with tiled layout |
 | `subagents_list` | List available agent definitions |
-| `set_tab_title` | Update cmux tab title to show progress |
+| `set_tab_title` | Update tab/window title to show progress |
 | `subagent_resume` | Resume a previous sub-agent session |
 
 | Command | Description |
@@ -105,7 +120,7 @@ The `/plan` command orchestrates a full planning-to-implementation pipeline. It'
 
 **Phase 5** — A reviewer examines all changes, producing a prioritized report. P0/P1 issues get fixed immediately by additional workers. P2/P3 items are noted or skipped.
 
-Throughout the workflow, cmux tab titles update to show current phase:
+Throughout the workflow, tab/window titles update to show current phase:
 
 ```
 🔍 Investigating: dark mode    →    💬 Planning: dark mode
@@ -157,7 +172,7 @@ subagent({
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `name` | string | required | Display name (shown in cmux tab) |
+| `name` | string | required | Display name (shown in pane title/tab) |
 | `task` | string | required | Task prompt for the sub-agent |
 | `agent` | string | — | Load defaults from agent definition |
 | `interactive` | boolean | `true` | User collaborates vs. autonomous |
@@ -171,7 +186,7 @@ subagent({
 
 ## Parallel Subagents
 
-The `parallel_subagents` tool runs multiple autonomous sub-agents concurrently with a single tool call. Each agent gets its own cmux terminal in a tiled layout, and progress updates stream in as each agent completes.
+The `parallel_subagents` tool runs multiple autonomous sub-agents concurrently with a single tool call. Each agent gets its own pane in a tiled layout, and progress updates stream in as each agent completes.
 
 ```typescript
 parallel_subagents({
@@ -245,13 +260,26 @@ The frontmatter configures the agent defaults. The body becomes the system promp
 
 ## Requirements
 
-- [pi](https://github.com/badlogic/pi-mono) — the coding agent
-- [cmux](https://github.com/manaflow-ai/cmux) — terminal multiplexer for side-by-side splits
+- [pi](https://github.com/badlogic/pi-mono) - the coding agent
+- One supported multiplexer:
+  - [cmux](https://github.com/manaflow-ai/cmux)
+  - [tmux](https://github.com/tmux/tmux)
+  - [zellij](https://zellij.dev)
 
-Start pi inside cmux:
+Start pi inside one of them:
 
 ```bash
 cmux pi
+# or
+tmux new -A -s pi 'pi'
+# or
+zellij --session pi   # then run: pi
+```
+
+Optional backend override:
+
+```bash
+export PI_SUBAGENT_MUX=cmux   # or tmux, zellij
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pi-interactive-subagents",
   "version": "0.1.0",
   "type": "module",
-  "description": "Interactive subagents for pi — spawn, orchestrate, and manage sub-agent sessions in cmux terminals",
+  "description": "Interactive subagents for pi - spawn, orchestrate, and manage sub-agent sessions in cmux/tmux/zellij terminals",
   "keywords": ["pi-package"],
   "pi": {
     "extensions": [

--- a/pi-extension/subagents/cmux.ts
+++ b/pi-extension/subagents/cmux.ts
@@ -1,11 +1,98 @@
-import { execSync, execFile } from "node:child_process";
+import { execSync, execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
 
 const execFileAsync = promisify(execFile);
-import { basename } from "node:path";
+
+export type MuxBackend = "cmux" | "tmux" | "zellij";
+
+const commandAvailability = new Map<string, boolean>();
+
+function hasCommand(command: string): boolean {
+  if (commandAvailability.has(command)) {
+    return commandAvailability.get(command)!;
+  }
+
+  let available = false;
+  try {
+    execSync(`command -v ${command}`, { stdio: "ignore" });
+    available = true;
+  } catch {
+    available = false;
+  }
+
+  commandAvailability.set(command, available);
+  return available;
+}
+
+function muxPreference(): MuxBackend | null {
+  const pref = (process.env.PI_SUBAGENT_MUX ?? "").trim().toLowerCase();
+  if (pref === "cmux" || pref === "tmux" || pref === "zellij") return pref;
+  return null;
+}
+
+function isCmuxRuntimeAvailable(): boolean {
+  return !!process.env.CMUX_SOCKET_PATH && hasCommand("cmux");
+}
+
+function isTmuxRuntimeAvailable(): boolean {
+  return !!process.env.TMUX && hasCommand("tmux");
+}
+
+function isZellijRuntimeAvailable(): boolean {
+  return !!(process.env.ZELLIJ || process.env.ZELLIJ_SESSION_NAME) && hasCommand("zellij");
+}
 
 export function isCmuxAvailable(): boolean {
-  return !!process.env.CMUX_SOCKET_PATH;
+  return isCmuxRuntimeAvailable();
+}
+
+export function isTmuxAvailable(): boolean {
+  return isTmuxRuntimeAvailable();
+}
+
+export function isZellijAvailable(): boolean {
+  return isZellijRuntimeAvailable();
+}
+
+export function getMuxBackend(): MuxBackend | null {
+  const pref = muxPreference();
+  if (pref === "cmux") return isCmuxRuntimeAvailable() ? "cmux" : null;
+  if (pref === "tmux") return isTmuxRuntimeAvailable() ? "tmux" : null;
+  if (pref === "zellij") return isZellijRuntimeAvailable() ? "zellij" : null;
+
+  if (isCmuxRuntimeAvailable()) return "cmux";
+  if (isTmuxRuntimeAvailable()) return "tmux";
+  if (isZellijRuntimeAvailable()) return "zellij";
+  return null;
+}
+
+export function isMuxAvailable(): boolean {
+  return getMuxBackend() !== null;
+}
+
+export function muxSetupHint(): string {
+  const pref = muxPreference();
+  if (pref === "cmux") {
+    return "Start pi inside cmux (`cmux pi`).";
+  }
+  if (pref === "tmux") {
+    return "Start pi inside tmux (`tmux new -A -s pi 'pi'`).";
+  }
+  if (pref === "zellij") {
+    return "Start pi inside zellij (`zellij --session pi`, then run `pi`).";
+  }
+  return "Start pi inside cmux (`cmux pi`), tmux (`tmux new -A -s pi 'pi'`), or zellij (`zellij --session pi`, then run `pi`).";
+}
+
+function requireMuxBackend(): MuxBackend {
+  const backend = getMuxBackend();
+  if (!backend) {
+    throw new Error(`No supported terminal multiplexer found. ${muxSetupHint()}`);
+  }
+  return backend;
 }
 
 /**
@@ -28,107 +115,339 @@ export function shellEscape(s: string): string {
   return "'" + s.replace(/'/g, "'\\''") + "'";
 }
 
+function tailLines(text: string, lines: number): string {
+  const split = text.split("\n");
+  if (split.length <= lines) return text;
+  return split.slice(-lines).join("\n");
+}
+
+function zellijPaneId(surface: string): string {
+  return surface.startsWith("pane:") ? surface.slice("pane:".length) : surface;
+}
+
+function zellijEnv(surface?: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  if (surface) {
+    env.ZELLIJ_PANE_ID = zellijPaneId(surface);
+  }
+  return env;
+}
+
+function waitForFile(path: string, timeoutMs = 5000): string {
+  const sleeper = new Int32Array(new SharedArrayBuffer(4));
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (existsSync(path)) {
+      return readFileSync(path, "utf8").trim();
+    }
+    Atomics.wait(sleeper, 0, 0, 20);
+  }
+  throw new Error(`Timed out waiting for zellij pane id file: ${path}`);
+}
+
+function zellijActionSync(args: string[], surface?: string): string {
+  return execFileSync("zellij", ["action", ...args], {
+    encoding: "utf8",
+    env: zellijEnv(surface),
+  });
+}
+
+async function zellijActionAsync(args: string[], surface?: string): Promise<string> {
+  const { stdout } = await execFileAsync("zellij", ["action", ...args], {
+    encoding: "utf8",
+    env: zellijEnv(surface),
+  });
+  return stdout;
+}
+
 /**
- * Create a new cmux terminal as a right split and set its tab title.
- * The subagent appears side-by-side with the orchestrator.
- * Returns the surface ref (e.g. "surface:42").
+ * Create a new terminal pane as a right split and set its title.
+ * Returns an identifier (`surface:42` in cmux, `%12` in tmux, `pane:7` in zellij).
  */
 export function createSurface(name: string): string {
   return createSurfaceSplit(name, "right");
 }
 
 /**
- * Create a new cmux terminal split in the given direction from an optional
- * source surface. Sets the tab title and focuses the new panel.
- * Returns the surface ref (e.g. "surface:42").
+ * Create a new split in the given direction from an optional source pane.
+ * Returns an identifier (`surface:42` in cmux, `%12` in tmux, `pane:7` in zellij).
  */
 export function createSurfaceSplit(
   name: string,
   direction: "left" | "right" | "up" | "down",
   fromSurface?: string,
 ): string {
-  const surfaceArg = fromSurface ? ` --surface ${shellEscape(fromSurface)}` : "";
-  const out = execSync(`cmux new-split ${direction}${surfaceArg}`, {
-    encoding: "utf8",
-  }).trim();
-  // Output: "OK surface:42 workspace:3"
-  const match = out.match(/surface:\d+/);
-  if (!match) {
-    throw new Error(`Unexpected cmux new-split output: ${out}`);
+  const backend = requireMuxBackend();
+
+  if (backend === "cmux") {
+    const surfaceArg = fromSurface ? ` --surface ${shellEscape(fromSurface)}` : "";
+    const out = execSync(`cmux new-split ${direction}${surfaceArg}`, {
+      encoding: "utf8",
+    }).trim();
+    const match = out.match(/surface:\d+/);
+    if (!match) {
+      throw new Error(`Unexpected cmux new-split output: ${out}`);
+    }
+    const surface = match[0];
+    execSync(`cmux rename-tab --surface ${shellEscape(surface)} ${shellEscape(name)}`, {
+      encoding: "utf8",
+    });
+    execSync(`cmux focus-panel --panel ${shellEscape(surface)}`, {
+      encoding: "utf8",
+    });
+    return surface;
   }
-  const surface = match[0];
-  // Rename the tab so the subagent name is visible
-  execSync(`cmux rename-tab --surface ${shellEscape(surface)} ${shellEscape(name)}`, {
-    encoding: "utf8",
-  });
-  // Focus the new split so the user doesn't accidentally type in the orchestrator
-  execSync(`cmux focus-panel --panel ${shellEscape(surface)}`, {
-    encoding: "utf8",
-  });
+
+  if (backend === "tmux") {
+    const args = ["split-window"];
+    if (direction === "left" || direction === "right") {
+      args.push("-h");
+    } else {
+      args.push("-v");
+    }
+    if (direction === "left" || direction === "up") {
+      args.push("-b");
+    }
+    if (fromSurface) {
+      args.push("-t", fromSurface);
+    }
+    args.push("-P", "-F", "#{pane_id}");
+
+    const pane = execFileSync("tmux", args, { encoding: "utf8" }).trim();
+    if (!pane.startsWith("%")) {
+      throw new Error(`Unexpected tmux split-window output: ${pane}`);
+    }
+
+    try {
+      execFileSync("tmux", ["select-pane", "-t", pane, "-T", name], { encoding: "utf8" });
+    } catch {
+      // Optional.
+    }
+    execFileSync("tmux", ["select-pane", "-t", pane], { encoding: "utf8" });
+    return pane;
+  }
+
+  // zellij
+  const directionArg = direction === "left" || direction === "right" ? "right" : "down";
+  const tokenPath = join(
+    tmpdir(),
+    `pi-subagent-zellij-pane-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`
+  );
+  const args = ["new-pane", "--direction", directionArg, "--name", name, "--cwd", process.cwd()];
+
+  try {
+    zellijActionSync(args, fromSurface);
+  } catch {
+    if (!fromSurface) throw new Error("Failed to create zellij pane");
+    zellijActionSync(args);
+  }
+
+  // IMPORTANT: do not pass a long-running command to `new-pane`.
+  // zellij keeps the `action new-pane -- <cmd>` process attached until <cmd>
+  // exits. If <cmd> is an interactive shell, the parent call hangs forever.
+  // Instead, create a normal shell pane first, then ask the focused pane
+  // to print its own $ZELLIJ_PANE_ID into a temp file.
+  const captureIdCmd = `echo "$ZELLIJ_PANE_ID" > ${shellEscape(tokenPath)}`;
+  zellijActionSync(["write-chars", captureIdCmd]);
+  zellijActionSync(["write", "13"]);
+
+  const paneId = waitForFile(tokenPath);
+  try {
+    rmSync(tokenPath, { force: true });
+  } catch {}
+
+  if (!paneId || !/^\d+$/.test(paneId)) {
+    throw new Error(`Unexpected zellij pane id: ${paneId || "(empty)"}`);
+  }
+
+  const surface = `pane:${paneId}`;
+
+  if (direction === "left" || direction === "up") {
+    try {
+      zellijActionSync(["move-pane", direction], surface);
+    } catch {
+      // Optional layout polish.
+    }
+  }
+
+  try {
+    zellijActionSync(["rename-pane", name], surface);
+  } catch {
+    // Optional.
+  }
+
   return surface;
 }
 
 /**
- * Rename the current tab (the one running this process).
- * Explicitly passes CMUX_SURFACE_ID so it works even when the tab isn't focused.
+ * Rename the current tab/window.
  */
 export function renameCurrentTab(title: string): void {
-  const surfaceId = process.env.CMUX_SURFACE_ID;
-  if (!surfaceId) throw new Error("CMUX_SURFACE_ID not set");
-  execSync(`cmux rename-tab --surface ${shellEscape(surfaceId)} ${shellEscape(title)}`, { encoding: "utf8" });
+  const backend = requireMuxBackend();
+
+  if (backend === "cmux") {
+    const surfaceId = process.env.CMUX_SURFACE_ID;
+    if (!surfaceId) throw new Error("CMUX_SURFACE_ID not set");
+    execSync(`cmux rename-tab --surface ${shellEscape(surfaceId)} ${shellEscape(title)}`, { encoding: "utf8" });
+    return;
+  }
+
+  if (backend === "tmux") {
+    const paneId = process.env.TMUX_PANE;
+    if (!paneId) throw new Error("TMUX_PANE not set");
+    const windowId = execFileSync("tmux", ["display-message", "-p", "-t", paneId, "#{window_id}"], {
+      encoding: "utf8",
+    }).trim();
+    execFileSync("tmux", ["rename-window", "-t", windowId, title], { encoding: "utf8" });
+    return;
+  }
+
+  zellijActionSync(["rename-tab", title]);
 }
 
 /**
- * Rename the current workspace (sidebar entry).
- * Uses CMUX_WORKSPACE_ID from env automatically.
+ * Rename the current workspace/session where supported.
  */
 export function renameWorkspace(title: string): void {
-  execSync(`cmux workspace-action --action rename --title ${shellEscape(title)}`, { encoding: "utf8" });
+  const backend = requireMuxBackend();
+
+  if (backend === "cmux") {
+    execSync(`cmux workspace-action --action rename --title ${shellEscape(title)}`, { encoding: "utf8" });
+    return;
+  }
+
+  if (backend === "tmux") {
+    if (process.env.PI_SUBAGENT_RENAME_TMUX_SESSION !== "1") {
+      return;
+    }
+
+    const paneId = process.env.TMUX_PANE;
+    if (!paneId) throw new Error("TMUX_PANE not set");
+    const sessionId = execFileSync("tmux", ["display-message", "-p", "-t", paneId, "#{session_id}"], {
+      encoding: "utf8",
+    }).trim();
+    execFileSync("tmux", ["rename-session", "-t", sessionId, title], { encoding: "utf8" });
+    return;
+  }
+
+  zellijActionSync(["rename-session", title]);
 }
 
 /**
- * Send a command string to a cmux surface. Appends \n to execute.
+ * Send a command string to a pane and execute it.
  */
 export function sendCommand(surface: string, command: string): void {
-  execSync(`cmux send --surface ${shellEscape(surface)} ${shellEscape(command + "\n")}`, {
-    encoding: "utf8",
-  });
+  const backend = requireMuxBackend();
+
+  if (backend === "cmux") {
+    execSync(`cmux send --surface ${shellEscape(surface)} ${shellEscape(command + "\n")}`, {
+      encoding: "utf8",
+    });
+    return;
+  }
+
+  if (backend === "tmux") {
+    execFileSync("tmux", ["send-keys", "-t", surface, "-l", command], { encoding: "utf8" });
+    execFileSync("tmux", ["send-keys", "-t", surface, "Enter"], { encoding: "utf8" });
+    return;
+  }
+
+  zellijActionSync(["write-chars", command], surface);
+  zellijActionSync(["write", "13"], surface);
 }
 
 /**
- * Read the screen contents of a cmux surface (sync).
+ * Read the screen contents of a pane (sync).
  */
 export function readScreen(surface: string, lines = 50): string {
-  return execSync(
-    `cmux read-screen --surface ${shellEscape(surface)} --lines ${lines}`,
-    { encoding: "utf8" }
+  const backend = requireMuxBackend();
+
+  if (backend === "cmux") {
+    return execSync(
+      `cmux read-screen --surface ${shellEscape(surface)} --lines ${lines}`,
+      { encoding: "utf8" }
+    );
+  }
+
+  if (backend === "tmux") {
+    return execFileSync("tmux", ["capture-pane", "-p", "-t", surface, "-S", `-${Math.max(1, lines)}`], {
+      encoding: "utf8",
+    });
+  }
+
+  const tmpPath = join(
+    tmpdir(),
+    `pi-subagent-zellij-screen-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`
   );
+  try {
+    zellijActionSync(["dump-screen", tmpPath], surface);
+    const raw = readFileSync(tmpPath, "utf8");
+    return tailLines(raw, lines);
+  } finally {
+    try { rmSync(tmpPath, { force: true }); } catch {}
+  }
 }
 
 /**
- * Read the screen contents of a cmux surface (async).
- * Does not block the event loop, so UI updates (setStatus, etc.) can render.
+ * Read the screen contents of a pane (async).
  */
 export async function readScreenAsync(surface: string, lines = 50): Promise<string> {
-  const { stdout } = await execFileAsync(
-    "cmux",
-    ["read-screen", "--surface", surface, "--lines", String(lines)],
-    { encoding: "utf8" }
+  const backend = requireMuxBackend();
+
+  if (backend === "cmux") {
+    const { stdout } = await execFileAsync(
+      "cmux",
+      ["read-screen", "--surface", surface, "--lines", String(lines)],
+      { encoding: "utf8" }
+    );
+    return stdout;
+  }
+
+  if (backend === "tmux") {
+    const { stdout } = await execFileAsync(
+      "tmux",
+      ["capture-pane", "-p", "-t", surface, "-S", `-${Math.max(1, lines)}`],
+      { encoding: "utf8" }
+    );
+    return stdout;
+  }
+
+  const tmpPath = join(
+    tmpdir(),
+    `pi-subagent-zellij-screen-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`
   );
-  return stdout;
+  try {
+    await zellijActionAsync(["dump-screen", tmpPath], surface);
+    const raw = readFileSync(tmpPath, "utf8");
+    return tailLines(raw, lines);
+  } finally {
+    try { rmSync(tmpPath, { force: true }); } catch {}
+  }
 }
 
 /**
- * Close a cmux surface.
+ * Close a pane.
  */
 export function closeSurface(surface: string): void {
-  execSync(`cmux close-surface --surface ${shellEscape(surface)}`, {
-    encoding: "utf8",
-  });
+  const backend = requireMuxBackend();
+
+  if (backend === "cmux") {
+    execSync(`cmux close-surface --surface ${shellEscape(surface)}`, {
+      encoding: "utf8",
+    });
+    return;
+  }
+
+  if (backend === "tmux") {
+    execFileSync("tmux", ["kill-pane", "-t", surface], { encoding: "utf8" });
+    return;
+  }
+
+  zellijActionSync(["close-pane"], surface);
 }
 
 /**
- * Poll a surface until the __SUBAGENT_DONE_N__ sentinel appears.
+ * Poll a pane until the __SUBAGENT_DONE_N__ sentinel appears.
  * Returns the process exit code embedded in the sentinel.
  * Throws if the signal is aborted before the sentinel is found.
  */

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -6,7 +6,8 @@ import { basename, dirname, join } from "node:path";
 import { readdirSync, statSync, readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import {
-  isCmuxAvailable,
+  isMuxAvailable,
+  muxSetupHint,
   createSurface,
   createSurfaceSplit,
   sendCommand,
@@ -104,6 +105,20 @@ function formatElapsed(seconds: number): string {
   return `${m}m ${s}s`;
 }
 
+function muxUnavailableResult(kind: "subagents" | "tab-title" = "subagents") {
+  if (kind === "tab-title") {
+    return {
+      content: [{ type: "text" as const, text: `Terminal multiplexer not available. ${muxSetupHint()}` }],
+      details: { error: "mux not available" },
+    };
+  }
+
+  return {
+    content: [{ type: "text" as const, text: `Subagents require a supported terminal multiplexer. ${muxSetupHint()}` }],
+    details: { error: "mux not available" },
+  };
+}
+
 /**
  * Build the artifact directory path for the current session.
  * Same convention as the write_artifact tool:
@@ -181,7 +196,7 @@ interface SubagentResult {
 }
 
 /**
- * Core subagent execution logic. Spawns a sub-agent in a cmux terminal,
+ * Core subagent execution logic. Spawns a sub-agent in a multiplexer pane,
  * polls for completion, extracts the summary, and returns a structured result.
  *
  * Used by both `subagent` (single) and `parallel_subagents` (concurrent) tools.
@@ -378,20 +393,17 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     name: "subagent",
     label: "Subagent",
     description:
-      "Spawn a sub-agent in a dedicated cmux terminal with shared session context. " +
+      "Spawn a sub-agent in a dedicated terminal multiplexer pane with shared session context. " +
       "The sub-agent branches from the current session, works independently (interactive or autonomous), " +
-      "and returns results via a branch summary. Requires cmux to be running (CMUX_SOCKET_PATH must be set).",
+      "and returns results via a branch summary. Supports cmux, tmux, and zellij.",
     parameters: SubagentParams,
 
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
       const interactive = params.interactive !== false;
 
       // Validate prerequisites
-      if (!isCmuxAvailable()) {
-        return {
-          content: [{ type: "text", text: "Subagents require cmux. Start pi inside cmux (`cmux pi`) to use interactive subagents." }],
-          details: { error: "cmux not available" },
-        };
+      if (!isMuxAvailable()) {
+        return muxUnavailableResult("subagents");
       }
 
       if (!ctx.sessionManager.getSessionFile()) {
@@ -588,8 +600,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     name: "parallel_subagents",
     label: "Parallel Subagents",
     description:
-      "Run multiple autonomous sub-agents concurrently. Each agent spawns in its own cmux terminal " +
-      "and runs independently. Results stream in as each agent completes — you don't have to wait for all of them. " +
+      "Run multiple autonomous sub-agents concurrently. Each agent spawns in its own multiplexer pane " +
+      "and runs independently. Results stream in as each agent completes so you do not have to wait for all of them. " +
       "Use for independent tasks like scouting different parts of a codebase, parallel research, or non-overlapping work.",
     parameters: Type.Object({
       agents: Type.Array(ParallelSubagentEntry, {
@@ -599,11 +611,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     }),
 
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
-      if (!isCmuxAvailable()) {
-        return {
-          content: [{ type: "text", text: "Subagents require cmux. Start pi inside cmux (`cmux pi`) to use interactive subagents." }],
-          details: { error: "cmux not available" },
-        };
+      if (!isMuxAvailable()) {
+        return muxUnavailableResult("subagents");
       }
 
       if (!ctx.sessionManager.getSessionFile()) {
@@ -893,23 +902,20 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     },
   });
 
-  // set_tab_title tool — update the current cmux tab title and workspace
+  // set_tab_title tool — update the current tab/window title and workspace/session
   pi.registerTool({
     name: "set_tab_title",
     label: "Set Tab Title",
     description:
-      "Update the current cmux tab and workspace title. Use to show progress during multi-phase workflows " +
+      "Update the current tab/window and workspace/session title. Use to show progress during multi-phase workflows " +
       "(e.g. planning, executing todos, reviewing). Keep titles short and informative.",
     parameters: Type.Object({
-      title: Type.String({ description: "New tab title (also applied to the workspace sidebar)" }),
+      title: Type.String({ description: "New tab title (also applied to workspace/session when supported)" }),
     }),
 
     async execute(_toolCallId, params) {
-      if (!isCmuxAvailable()) {
-        return {
-          content: [{ type: "text", text: "cmux not available — start pi inside cmux (`cmux pi`) to set tab titles." }],
-          details: { error: "cmux not available" },
-        };
+      if (!isMuxAvailable()) {
+        return muxUnavailableResult("tab-title");
       }
       try {
         renameCurrentTab(params.title);
@@ -932,7 +938,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     name: "subagent_resume",
     label: "Resume Subagent",
     description:
-      "Resume a previous sub-agent session in a new cmux terminal. " +
+      "Resume a previous sub-agent session in a new multiplexer pane. " +
       "Opens an interactive session from the given session file path. " +
       "Use when a sub-agent was cancelled or needs follow-up work.",
     parameters: Type.Object({
@@ -1000,11 +1006,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
       const name = params.name ?? "Resume";
       const startTime = Date.now();
 
-      if (!isCmuxAvailable()) {
-        return {
-          content: [{ type: "text", text: "Subagents require cmux. Start pi inside cmux (`cmux pi`) to use interactive subagents." }],
-          details: { error: "cmux not available" },
-        };
+      if (!isMuxAvailable()) {
+        return muxUnavailableResult("subagents");
       }
 
       if (!existsSync(params.sessionPath)) {
@@ -1157,13 +1160,13 @@ export default function subagentsExtension(pi: ExtensionAPI) {
       }
 
       // Rename workspace and tab to show this is a planning session
-      if (isCmuxAvailable()) {
+      if (isMuxAvailable()) {
         try {
-          const label = task.length > 40 ? task.slice(0, 40) + "…" : task;
+          const label = task.length > 40 ? task.slice(0, 40) + "..." : task;
           renameWorkspace(`🎯 ${label}`);
           renameCurrentTab(`🎯 Plan: ${label}`);
         } catch {
-          // non-critical — don't block the plan
+          // non-critical -- do not block the plan
         }
       }
 

--- a/pi-extension/subagents/plan-skill.md
+++ b/pi-extension/subagents/plan-skill.md
@@ -2,9 +2,9 @@
 name: plan
 description: >
   Planning workflow. Spawns an interactive planner sub-agent
-  in a cmux terminal with shared session context. Use when asked to "plan",
+  in a multiplexer pane with shared session context. Use when asked to "plan",
   "brainstorm", "I want to build X", or "let's design". Requires the
-  subagents extension and cmux.
+  subagents extension and a supported multiplexer (cmux/tmux/zellij).
 ---
 
 # Plan
@@ -17,7 +17,7 @@ A planning workflow that offloads brainstorming and plan creation to a dedicated
 
 ## Tab Titles
 
-Use `set_tab_title` to keep the user informed of progress in the cmux sidebar. Update the title at every phase transition.
+Use `set_tab_title` to keep the user informed of progress in the multiplexer UI. Update the title at every phase transition.
 
 | Phase | Title example |
 |-------|--------------|


### PR DESCRIPTION
## Summary
- add multiplexer abstraction and backend detection for cmux, tmux, and zellij
- implement pane/tab/session operations for tmux and zellij (create split, rename, send command, read screen, close pane)
- wire subagent tools to work across all three backends
- update docs and extension descriptions to document cmux/tmux/zellij support

## Testing
- manual smoke test in zellij:
  - `set_tab_title` updates tab/session title
  - autonomous `subagent` completes and returns summary
- `npm test` currently fails in this repo because Node test runner does not execute `.ts` directly (existing project setup issue)
