### PR TITLE
feat(cmux): allow disabling window renaming using envar PI_SUBAGENT_RENAME_TMUX_WINDOW

### DIFF
--- a/pi-extension/subagents/cmux.ts
+++ b/pi-extension/subagents/cmux.ts
@@ -291,6 +291,9 @@ export function renameCurrentTab(title: string): void {
   }
 
   if (backend === "tmux") {
+    if (process.env.PI_SUBAGENT_RENAME_TMUX_WINDOW !== "1") {
+      return;
+    }
     const paneId = process.env.TMUX_PANE;
     if (!paneId) throw new Error("TMUX_PANE not set");
     const windowId = execFileSync("tmux", ["display-message", "-p", "-t", paneId, "#{window_id}"], {


### PR DESCRIPTION
Add an opt-out guard in renameCurrentTab so tmux window renaming is skipped
when PI_SUBAGENT_RENAME_TMUX_WINDOW is set to false.

---

Context: While the feature is great, I don't like this extension renaming my tmux sessions/windows. Disabling session renaming was already present; adding an option to disable window renaming as well.