### PR TITLE
fix #20 and long subagent commands error

### DIFF
--- a/pi-extension/subagents/cmux.ts
+++ b/pi-extension/subagents/cmux.ts
@@ -1,6 +1,6 @@
 import { execSync, execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 
@@ -489,6 +489,29 @@ export function sendCommand(surface: string, command: string): void {
 
   zellijActionSync(["write-chars", command], surface);
   zellijActionSync(["write", "13"], surface);
+}
+
+/**
+ * Send a long command to a pane by writing it to a temporary script file first.
+ * This avoids terminal line-wrapping issues that break commands exceeding the
+ * pane's column width when sent character-by-character via sendCommand.
+ *
+ * The script is self-cleaning: it removes itself after execution.
+ * Returns the path to the temporary script (for reference / debugging).
+ */
+export function sendLongCommand(surface: string, command: string): string {
+  const scriptDir = join(tmpdir(), "pi-subagent-scripts");
+  mkdirSync(scriptDir, { recursive: true });
+  const scriptPath = join(
+    scriptDir,
+    `cmd-${Date.now()}-${Math.random().toString(16).slice(2, 8)}.sh`,
+  );
+  // Write a bash script that runs the command then cleans itself up
+  writeFileSync(scriptPath, `#!/bin/bash\n${command}\nrm -f ${shellEscape(scriptPath)}\n`, {
+    mode: 0o755,
+  });
+  sendCommand(surface, `bash ${shellEscape(scriptPath)}`);
+  return scriptPath;
 }
 
 /**

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -616,7 +616,7 @@ async function launchSubagent(
     const artifactPath = join(artifactDir, artifactName);
     mkdirSync(dirname(artifactPath), { recursive: true });
     writeFileSync(artifactPath, fullTask, "utf8");
-    parts.push(`@${artifactPath}`);
+    parts.push(shellEscape(`@${artifactPath}`));
   }
 
   // Resolve cwd — param overrides agent default, supports absolute and relative paths.
@@ -1158,7 +1158,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
           const msgFile = join(tmpdir(), `subagent-resume-${Date.now()}.md`);
           writeFileSync(msgFile, params.message, "utf8");
           cleanupMsgFile = msgFile;
-          parts.push(`@${msgFile}`);
+          parts.push(shellEscape(`@${msgFile}`));
         }
 
         // Build env prefix — propagate PI_CODING_AGENT_DIR for config isolation

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -17,11 +17,10 @@ import {
   isMuxAvailable,
   muxSetupHint,
   createSurface,
-  sendCommand,
+  sendLongCommand,
   pollForExit,
   closeSurface,
   shellEscape,
-  exitStatusVar,
   renameCurrentTab,
   renameWorkspace,
 } from "./cmux.ts";
@@ -624,8 +623,8 @@ async function launchSubagent(
   const cdPrefix = effectiveCwd ? `cd ${shellEscape(effectiveCwd)} && ` : "";
 
   const piCommand = cdPrefix + envPrefix + parts.join(" ");
-  const command = `${piCommand}; echo '__SUBAGENT_DONE_'${exitStatusVar()}'__'`;
-  sendCommand(surface, command);
+  const command = `${piCommand}; echo '__SUBAGENT_DONE_'$?'__'`;
+  sendLongCommand(surface, command);
 
   const running: RunningSubagent = {
     id,
@@ -1168,8 +1167,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         }
         const resumeEnvPrefix = resumeEnvParts.length > 0 ? resumeEnvParts.join(" ") + " " : "";
 
-        const command = `${resumeEnvPrefix}${parts.join(" ")}${cleanupMsgFile ? `; rm -f ${shellEscape(cleanupMsgFile)}` : ""}; echo '__SUBAGENT_DONE_'${exitStatusVar()}'__'`;
-        sendCommand(surface, command);
+        const command = `${resumeEnvPrefix}${parts.join(" ")}${cleanupMsgFile ? `; rm -f ${shellEscape(cleanupMsgFile)}` : ""}; echo '__SUBAGENT_DONE_'$?'__'`;
+        sendLongCommand(surface, command);
 
         // Register as a running subagent for widget tracking
         const id = Math.random().toString(16).slice(2, 10);


### PR DESCRIPTION
1. Fixes https://github.com/HazAT/pi-interactive-subagents/issues/20. The https://github.com/file arguments for artifact paths and resume message
paths were passed to the shell without quoting, causing breakage when
the repo/session path contained spaces (e.g. 'Code Forge').

Wrap both occurrences with shellEscape() to properly single-quote them.

2. When the pi command (with env vars, paths, flags) exceeds the terminal
pane's column width, sendCommand sends it character-by-character which
causes line wrapping that breaks shell input handling.

Fix: add sendLongCommand() that writes the full command to a temporary
bash script (/tmp/pi-subagent-scripts/cmd-*.sh) and sends only a short
'bash /path/to/script.sh' (~60 chars) to the pane. The script self-
deletes after execution.
