### PR TITLE
fix(cmux): zellij correctness for pane-id targeting (new, close, rename)

### DIFF
--- a/pi-extension/subagents/cmux.ts
+++ b/pi-extension/subagents/cmux.ts
@@ -159,14 +159,22 @@ function waitForFile(path: string, timeoutMs = 5000): string {
 }
 
 function zellijActionSync(args: string[], surface?: string): string {
-  return execFileSync("zellij", ["action", ...args], {
+  const fullArgs = ["action", ...args];
+  if (surface) {
+    fullArgs.push("--pane-id", zellijPaneId(surface));
+  }
+  return execFileSync("zellij", fullArgs, {
     encoding: "utf8",
     env: zellijEnv(surface),
   });
 }
 
 async function zellijActionAsync(args: string[], surface?: string): Promise<string> {
-  const { stdout } = await execFileAsync("zellij", ["action", ...args], {
+  const fullArgs = ["action", ...args];
+  if (surface) {
+    fullArgs.push("--pane-id", zellijPaneId(surface));
+  }
+  const { stdout } = await execFileAsync("zellij", fullArgs, {
     encoding: "utf8",
     env: zellijEnv(surface),
   });
@@ -317,37 +325,28 @@ export function createSurfaceSplit(
   }
 
   // zellij
+  // `new-pane` returns the pane ID in stdout (e.g. "terminal_7").
+  // Use it directly instead of the old temp-file approach, which was
+  // racy: write-chars without --pane-id targets the focused pane,
+  // so switching Zellij tabs between new-pane and write-chars sent
+  // the ID-capture command to the wrong pane.
   const directionArg = direction === "left" || direction === "right" ? "right" : "down";
-  const tokenPath = join(
-    tmpdir(),
-    `pi-subagent-zellij-pane-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`,
-  );
   const args = ["new-pane", "--direction", directionArg, "--name", name, "--cwd", process.cwd()];
 
+  let rawId: string;
   try {
-    zellijActionSync(args, fromSurface);
+    rawId = zellijActionSync(args, fromSurface).trim();
   } catch {
     if (!fromSurface) throw new Error("Failed to create zellij pane");
-    zellijActionSync(args);
+    rawId = zellijActionSync(args).trim();
   }
 
-  // IMPORTANT: do not pass a long-running command to `new-pane`.
-  // zellij keeps the `action new-pane -- <cmd>` process attached until <cmd>
-  // exits. If <cmd> is an interactive shell, the parent call hangs forever.
-  // Instead, create a normal shell pane first, then ask the focused pane
-  // to print its own $ZELLIJ_PANE_ID into a temp file.
-  const captureIdCmd = `echo "$ZELLIJ_PANE_ID" > ${shellEscape(tokenPath)}`;
-  zellijActionSync(["write-chars", captureIdCmd]);
-  zellijActionSync(["write", "13"]);
-
-  const paneId = waitForFile(tokenPath);
-  try {
-    rmSync(tokenPath, { force: true });
-  } catch {}
-
-  if (!paneId || !/^\d+$/.test(paneId)) {
-    throw new Error(`Unexpected zellij pane id: ${paneId || "(empty)"}`);
+  // new-pane returns e.g. "terminal_7" — extract the numeric part
+  const idMatch = rawId.match(/(\d+)/);
+  if (!idMatch) {
+    throw new Error(`Unexpected zellij pane id from new-pane: ${rawId || "(empty)"}`);
   }
+  const paneId = idMatch[1];
 
   const surface = `pane:${paneId}`;
 

--- a/pi-extension/subagents/cmux.ts
+++ b/pi-extension/subagents/cmux.ts
@@ -404,7 +404,16 @@ export function renameCurrentTab(title: string): void {
     return;
   }
 
-  zellijActionSync(["rename-tab", title]);
+  // zellij: rename the agent's own pane, not the whole tab. In multi-pane
+  // layouts the tab title applies to unrelated sibling panes, which is noisy.
+  // ZELLIJ_PANE_ID is set in every pane's environment, so target our own
+  // pane explicitly rather than whatever pane happens to be focused.
+  const paneId = process.env.ZELLIJ_PANE_ID;
+  if (paneId) {
+    zellijActionSync(["rename-pane", title], `pane:${paneId}`);
+  } else {
+    zellijActionSync(["rename-pane", title]);
+  }
 }
 
 /**

--- a/pi-extension/subagents/cmux.ts
+++ b/pi-extension/subagents/cmux.ts
@@ -639,7 +639,13 @@ export function closeSurface(surface: string): void {
     return;
   }
 
-  zellijActionSync(["close-pane"], surface);
+  // close-pane supports --pane-id (zellij 0.44+), same as dump-screen.
+  // Call execFileSync directly so we don't also set ZELLIJ_PANE_ID in the
+  // child env — close-pane doesn't need it and the targeting is explicit.
+  const paneId = zellijPaneId(surface);
+  execFileSync("zellij", ["action", "close-pane", "--pane-id", paneId], {
+    encoding: "utf8",
+  });
 }
 
 export interface PollResult {


### PR DESCRIPTION
## Summary

Three related zellij correctness fixes for the subagents extension.

*Rebased onto v3.0.0.* Commit 3 was scoped down during the rebase because v3.0.0's `refactor(subagents): remove set_tab_title tool` deleted the tool surface; only the `renameCurrentTab` helper change in `cmux.ts` remains, which is still useful because `/plan` calls `renameCurrentTab` directly.

### 1. `createSurfaceSplit` captures pane ID from `new-pane` stdout (commit 1)

The previous approach typed `echo $ZELLIJ_PANE_ID > /tmp/...` into the new pane via `write-chars`, then polled the temp file for the ID. But `write-chars` without `--pane-id` targets the focused pane, not the just-created one. If focus drifted between `new-pane` and `write-chars` (e.g. the user switched tabs), the capture command ran in the wrong pane and either wrote a bad ID or never wrote at all (timeout).

`zellij action new-pane` already prints the new pane's ID on stdout (e.g. `terminal_7`), so we read it directly. Deterministic, no focus dependency, no filesystem handshake.

This commit also threads the optional `surface` parameter of `zellijActionSync`/`zellijActionAsync` into an explicit `--pane-id <n>` argument so later callers (close-pane, rename-pane) can target a specific pane regardless of focus.

### 2. `closeSurface` passes `--pane-id` explicitly (commit 2)

After the helper upgrade in commit 1, `closeSurface` would implicitly get correct targeting, but we prefer to invoke `zellij action close-pane --pane-id <id>` directly via `execFileSync`. This skips the helper's (unneeded) ZELLIJ_PANE_ID env var manipulation and makes the targeting unambiguous at the call site. Can be squashed into commit 1 if you prefer.

### 3. `renameCurrentTab` renames the agent's pane, not the whole tab (commit 3)

In zellij, multiple panes share a tab, and the tab title applies to all of them. `renameCurrentTab` is still used on v3.0.0 by the `/plan` skill to label the planning session. The previous implementation called `rename-tab`, which labeled sibling panes unrelated to the agent's task. Noisy in any multi-pane layout.

Switched the zellij branch of `renameCurrentTab` to `rename-pane`, targeting via `ZELLIJ_PANE_ID` (set by zellij in every pane's environment) rather than relying on focus.

Other multiplexers (cmux/tmux/wezterm) are unchanged; their tab/window rename semantics are appropriate for their layout models.

## Test plan

Tested locally in zellij with pi-interactive-subagents enabled:

- [x] Baseline reproduced: pre-patch subagent tab rename relabels unrelated sibling panes.
- [x] After patch, subagent in a multi-pane layout labels only the agent's pane. Sibling panes and tab title stay untouched.
- [x] Multiple subagents in parallel panes of the same tab each get their own distinct pane title, no clobbering.
- [x] Focus-during-rename: clicking into a sibling pane while a subagent updates its title; the rename still lands on the agent's pane (confirms `ZELLIJ_PANE_ID` targeting, not focus-based).
- [x] Pane creation under load no longer produces occasional "Unexpected zellij pane id" errors from the old `waitForFile` timeout path.

## Notes

- `waitForFile` is unused after commit 1. Left in place to keep the diff minimal; happy to follow up with a cleanup commit if you prefer.
- Commits are split for reviewability. Squash on merge if preferred.
