### PR TITLE
fix(subagents): make shell startup delay configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ zellij --session pi   # then run: pi
 
 Optional: set `PI_SUBAGENT_MUX=cmux|tmux|zellij|wezterm` to force a specific backend.
 
+If your shell startup is slow and subagent commands sometimes get dropped before the prompt is ready, set `PI_SUBAGENT_SHELL_READY_DELAY_MS` to a higher value (defaults to `500`):
+
+```bash
+export PI_SUBAGENT_SHELL_READY_DELAY_MS=2500
+```
+
 ## What's Included
 
 ### Extensions

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -290,6 +290,19 @@ function formatElapsed(seconds: number): string {
   return `${m}m ${s}s`;
 }
 
+/**
+ * Wait long enough for a freshly created pane to finish shell startup.
+ *
+ * Some environments do extra shell-init work before the prompt is ready
+ * (for example direnv/devenv), so the delay is configurable for users who hit
+ * dropped commands. Keep the historical default at 500ms.
+ */
+function getShellReadyDelayMs(): number {
+  const raw = process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS?.trim();
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 500;
+}
+
 function muxUnavailableResult() {
   return {
     content: [
@@ -495,6 +508,7 @@ function updateWidget() {
 
 export const __test__ = {
   borderLine,
+  getShellReadyDelayMs,
   renderSubagentWidgetLines,
   loadAgentDefaults,
   discoverAgentDefinitions,
@@ -556,7 +570,7 @@ async function launchSubagent(
   const surfacePreCreated = !!options?.surface;
   const surface = options?.surface ?? createSurface(params.name);
   if (!surfacePreCreated) {
-    await new Promise<void>((resolve) => setTimeout(resolve, 500));
+    await new Promise<void>((resolve) => setTimeout(resolve, getShellReadyDelayMs()));
   }
 
   // ── Claude Code CLI path ──
@@ -1287,7 +1301,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         const entryCountBefore = getNewEntries(params.sessionPath, 0).length;
 
         const surface = createSurface(name);
-        await new Promise<void>((resolve) => setTimeout(resolve, 500));
+        await new Promise<void>((resolve) => setTimeout(resolve, getShellReadyDelayMs()));
 
         // Build pi resume command
         const parts = ["pi", "--session", shellEscape(params.sessionPath)];

--- a/test/test.ts
+++ b/test/test.ts
@@ -603,6 +603,38 @@ describe("subagent-done.ts", () => {
     });
   });
 });
+describe("subagent startup delay", () => {
+  it("defaults to 500ms when no env var is set", () => {
+    const testApi = (subagentsModule as any).__test__;
+    assert.ok(testApi, "expected subagents test helpers to be exported");
+    assert.equal(typeof testApi.getShellReadyDelayMs, "function");
+
+    const original = process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS;
+    delete process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS;
+    try {
+      assert.equal(testApi.getShellReadyDelayMs(), 500);
+    } finally {
+      if (original == null) delete process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS;
+      else process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS = original;
+    }
+  });
+
+  it("uses PI_SUBAGENT_SHELL_READY_DELAY_MS when it is set", () => {
+    const testApi = (subagentsModule as any).__test__;
+    assert.ok(testApi, "expected subagents test helpers to be exported");
+    assert.equal(typeof testApi.getShellReadyDelayMs, "function");
+
+    const original = process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS;
+    process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS = "2500";
+    try {
+      assert.equal(testApi.getShellReadyDelayMs(), 2500);
+    } finally {
+      if (original == null) delete process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS;
+      else process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS = original;
+    }
+  });
+});
+
 describe("subagents widget rendering", () => {
   it("keeps every rendered line within a very narrow width", () => {
     const testApi = (subagentsModule as any).__test__;


### PR DESCRIPTION
## Summary

Make the subagent pane startup delay configurable via `PI_SUBAGENT_SHELL_READY_DELAY_MS` while preserving the existing 500ms default.

## Why

Some environments do extra shell initialization before the prompt is ready (for example `direnv` / `devenv`). In those cases the subagent launch command can be sent too early and get dropped.

This change keeps existing behavior by default, but lets affected users increase the delay without patching the extension.

## Changes

- add `getShellReadyDelayMs()` in `pi-extension/subagents/index.ts`
- use it for both:
  - new subagent launches
  - `subagent_resume`
- document `PI_SUBAGENT_SHELL_READY_DELAY_MS` in the README
- add tests covering:
  - default `500ms`
  - env override behavior

## Example

```bash
export PI_SUBAGENT_SHELL_READY_DELAY_MS=2500
```

## Validation

- `npm test`
