### PR TITLE
fix: insert empty positional arg so /skill: prompts expand correctly in artifact-backed launches

### DIFF
--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -528,6 +528,38 @@ function updateWidget() {
   );
 }
 
+/**
+ * Build the positional prompt args for a Pi CLI subagent launch.
+ *
+ * In artifact-backed launches (lineage-only, standalone), Pi's buildInitialMessage()
+ * concatenates @file content with messages[0] into one initial prompt. That breaks
+ * /skill: expansion because the message no longer starts with "/skill:". Only
+ * messages[1..] are sent as separate follow-up prompts where /skill: is recognized.
+ *
+ * When there are skill prompts AND artifact-backed delivery, we prepend an empty
+ * first positional message so that /skill: args land in messages[1..] and arrive
+ * as standalone prompts in the child session.
+ */
+function buildPiPromptArgs(params: {
+  effectiveSkills?: string;
+  taskDelivery: "direct" | "artifact";
+  taskArg: string;
+}): string[] {
+  const skillPrompts = (params.effectiveSkills ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((skill) => `/skill:${skill}`);
+
+  const needsSeparator = params.taskDelivery === "artifact" && skillPrompts.length > 0;
+
+  return [
+    ...(needsSeparator ? [""] : []),
+    ...skillPrompts,
+    params.taskArg,
+  ];
+}
+
 export const __test__ = {
   borderLine,
   getShellReadyDelayMs,
@@ -536,6 +568,7 @@ export const __test__ = {
   discoverAgentDefinitions,
   resolveEffectiveSessionMode,
   resolveLaunchBehavior,
+  buildPiPromptArgs,
 };
 
 function startWidgetRefresh() {
@@ -739,15 +772,6 @@ async function launchSubagent(
     }
   }
 
-  if (effectiveSkills) {
-    for (const skill of effectiveSkills
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean)) {
-      parts.push(shellEscape(`/skill:${skill}`));
-    }
-  }
-
   // Build env prefix: denied tools + subagent identity + config dir propagation
   const envParts: string[] = [];
 
@@ -773,12 +797,13 @@ async function launchSubagent(
   envParts.push(`PI_SUBAGENT_SURFACE=${shellEscape(surface)}`);
   const envPrefix = envParts.join(" ") + " ";
 
-  // Pass task to the sub-agent.
+  // Pass task and skill prompts to the sub-agent.
   // Only full-context fork mode gets a direct task argument because it already
   // inherits the parent conversation. Blank-session modes use artifact-backed
   // handoff so the wrapper instructions arrive as the initial user message.
+  let taskArg: string;
   if (launchBehavior.taskDelivery === "direct") {
-    parts.push(shellEscape(fullTask));
+    taskArg = fullTask;
   } else {
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
     const safeName = params.name
@@ -791,7 +816,15 @@ async function launchSubagent(
     const artifactPath = join(artifactDir, artifactName);
     mkdirSync(dirname(artifactPath), { recursive: true });
     writeFileSync(artifactPath, fullTask, "utf8");
-    parts.push(shellEscape(`@${artifactPath}`));
+    taskArg = `@${artifactPath}`;
+  }
+
+  for (const promptArg of buildPiPromptArgs({
+    effectiveSkills,
+    taskDelivery: launchBehavior.taskDelivery,
+    taskArg,
+  })) {
+    parts.push(shellEscape(promptArg));
   }
 
   // Resolve cwd — param overrides agent default, supports absolute and relative paths.

--- a/test/test.ts
+++ b/test/test.ts
@@ -470,6 +470,27 @@ describe("subagent discovery", () => {
     );
   });
 
+  it("buildPiPromptArgs inserts separator for artifact-backed launches with skills", () => {
+    assert.deepEqual(
+      testApi.buildPiPromptArgs({ effectiveSkills: "review,lint", taskDelivery: "artifact", taskArg: "@artifact.md" }),
+      ["", "/skill:review", "/skill:lint", "@artifact.md"],
+    );
+  });
+
+  it("buildPiPromptArgs omits separator for artifact-backed launches without skills", () => {
+    assert.deepEqual(
+      testApi.buildPiPromptArgs({ effectiveSkills: undefined, taskDelivery: "artifact", taskArg: "@artifact.md" }),
+      ["@artifact.md"],
+    );
+  });
+
+  it("buildPiPromptArgs omits separator for direct launches with skills", () => {
+    assert.deepEqual(
+      testApi.buildPiPromptArgs({ effectiveSkills: "review", taskDelivery: "direct", taskArg: "do the task" }),
+      ["/skill:review", "do the task"],
+    );
+  });
+
   it("lists visible agents from discovery", async () => {
     await withIsolatedAgentEnv(async ({ projectAgentsDir }) => {
       writeAgentFile(


### PR DESCRIPTION
Fixes `/skill:` expansion failing silently in artifact-backed subagent launches.  (This bug predates the `session-mode` introduced via https://github.com/HazAT/pi-interactive-subagents/commit/c1023b346f191c59a6e0d4b9949d789f0ae480e5: any launch path that delivers the task via `@file` can swallow a leading `/skill:` directive)

Pi's `buildInitialMessage()` concatenates `@file` content with `messages[0]` into a single initial prompt, so when the old code pushed `/skill:foo` as the first positional arg it ended up merged with the artifact content and never matched as a skill directive.  Only `messages[1..]` arrive as standalone follow-up prompts where `/skill:` expansion fires.

The fix extracts skill-prompt and task-arg assembly into a `buildPiPromptArgs` helper that prepends an empty first positional argument when both skill prompts and artifact-backed delivery are present.  This ensures `/skill:` args land in `messages[1..]` where Pi processes them correctly, while also co-locating the two concerns (skills + task arg) that were previously scattered across the launch function.  Direct full-context launches are unaffected since they don't concatenate the first message.

Changes:
- add `buildPiPromptArgs()` helper that builds the ordered positional-args array, inserting an empty separator when artifact delivery + skills co-occur
- refactor `launchSubagent` to delegate prompt-arg construction to `buildPiPromptArgs`, co-locating skill and task-arg assembly that was previously split across two distant blocks
- export `buildPiPromptArgs` via `__test__` for unit testing
- add three test cases: artifact+skills (separator inserted), artifact-only (no separator), direct+skills (no separator)