### PR TITLE
feat: add configurable subagent status supervision and turn-only interruption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+config.json
 .pi/*
 !.pi/skills/
 !.pi/settings.json

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ https://github.com/user-attachments/assets/30adb156-cfb4-4c47-84ca-dd4aa80cba9f
 
 ## How It Works
 
-Call `subagent()` and it **returns immediately**. The sub-agent runs in its own terminal pane. A live widget above the input shows all running agents with elapsed time and progress. When a sub-agent finishes, its result is **steered back** into the main session as an async notification — triggering a new turn so the agent can process it.
+Call `subagent()` and it **returns immediately**. The sub-agent runs in its own terminal pane. A live widget above the input shows all running agents with their current state — `active`, `quiet`, `stalled`, or `starting`. When a sub-agent finishes, its result is **steered back** into the main session as an async notification — triggering a new turn so the agent can process it.
 
 ```
-╭─ Subagents ──────────────────────── 2 running ─╮
-│ 00:23  Scout: Auth (scout)    8 msgs (5.1KB)   │
-│ 00:45  Scout: DB (scout)     12 msgs (9.3KB)   │
-╰─────────────────────────────────────────────────╯
+╭─ Subagents ────────────────────────── 2 running ─╮
+│ 00:23  Scout: Auth (scout)       active · 8 msgs │
+│ 00:45  Scout: DB (scout)                quiet 2m │
+╰──────────────────────────────────────────────────╯
 ```
 
 For parallel execution, just call `subagent` multiple times — they all run concurrently:
@@ -60,13 +60,14 @@ export PI_SUBAGENT_SHELL_READY_DELAY_MS=2500
 
 ### Extensions
 
-**Subagents** — 4 tools + 3 commands:
+**Subagents** — 4 main-session tools + 3 commands, plus 1 subagent-only tool:
 
-| Tool              | Description                                                                     |
-| ----------------- | ------------------------------------------------------------------------------- |
-| `subagent`        | Spawn a sub-agent in a dedicated multiplexer pane (async — returns immediately) |
-| `subagents_list`  | List available agent definitions                                                |
-| `subagent_resume` | Resume a previous sub-agent session (async)                                     |
+| Tool                 | Description                                                                                 |
+| -------------------- | ------------------------------------------------------------------------------------------- |
+| `subagent`           | Spawn a sub-agent in a dedicated multiplexer pane (async — returns immediately)             |
+| `subagent_interrupt` | Interrupt a running Pi-backed subagent's current turn                                       |
+| `subagents_list`     | List available agent definitions                                                            |
+| `subagent_resume`    | Resume a previous sub-agent session (async)                                                 |
 
 | Command                    | Description                          |
 | -------------------------- | ------------------------------------ |
@@ -91,24 +92,64 @@ Agent discovery follows priority: **project-local** (`.pi/agents/`) > **global**
 ## Async Subagent Flow
 
 ```
-1. Agent calls subagent()         → returns immediately ("started")
-2. Sub-agent runs in mux pane     → widget shows live progress
+1. Agent calls subagent()          → returns immediately ("started")
+2. Sub-agent runs in mux pane      → widget shows live status
 3. User keeps chatting             → main session fully interactive
-4. Sub-agent finishes              → result steered back as interrupt
+4. Sub-agent finishes              → result steered back as a normal completion/failure
 5. Main agent processes result     → continues with new context
 ```
 
 Multiple subagents run concurrently — each steers its result back independently as it finishes. The live widget above the input tracks all running agents:
 
 ```
-╭─ Subagents ──────────────────────── 3 running ─╮
-│ 01:23  Scout: Auth (scout)      15 msgs (12KB) │
-│ 00:45  Researcher (researcher)   8 msgs (6KB)  │
-│ 00:12  Scout: DB (scout)             starting…  │
-╰─────────────────────────────────────────────────╯
+╭─ Subagents ─────────────────────────── 3 running ─╮
+│ 01:23  Scout: Auth (scout)       active · 15 msgs │
+│ 00:45  Researcher (researcher)         stalled 4m │
+│ 00:12  Scout: DB (scout)                starting… │
+╰───────────────────────────────────────────────────╯
 ```
 
 Completion messages render with a colored background and are expandable with `Ctrl+O` to show the full summary and session file path.
+
+### In-progress status updates
+
+The widget tracks each sub-agent's progress and labels it with a coarse state:
+
+- `starting` — launched, but no progress observed yet
+- `active` — recent progress observed
+- `quiet` — still running, but no recent progress
+- `stalled` — no progress for an extended period
+- `running` — fallback for backends without progress tracking (e.g. Claude)
+
+These labels are derived from session-file activity. The `defaultCadenceSeconds` setting controls the idle-time thresholds: with the default of `60`, a run becomes `quiet` after about 1 minute without progress and `stalled` after about 3 minutes. When a run enters `stalled` or recovers from it, the parent agent receives a steer message so it can react. All other status transitions stay in the widget only.
+
+#### Configuration
+
+Status defaults come from `config.json` in the extension directory. Copy `config.json.example` to get started:
+
+```bash
+cp config.json.example config.json
+```
+
+```json
+{
+  "status": {
+    "enabled": true,
+    "defaultCadenceSeconds": 60
+  }
+}
+```
+
+`config.json` is gitignored so local overrides don't get committed. You can also override per run:
+
+```typescript
+subagent({
+  name: "Scout",
+  agent: "scout",
+  statusCadenceSeconds: 30,
+  task: "Analyze the auth module",
+});
+```
 
 ---
 
@@ -126,21 +167,43 @@ subagent({ name: "Planner", agent: "planner", task: "Work through the design wit
 
 // Custom working directory
 subagent({ name: "Designer", agent: "game-designer", cwd: "agents/game-designer", task: "..." });
+
+// Override the status classification window for this run
+subagent({ name: "Scout", agent: "scout", statusCadenceSeconds: 30, task: "..." });
 ```
 
 ### Parameters
 
-| Parameter      | Type    | Default  | Description                                                             |
-| -------------- | ------- | -------- | ----------------------------------------------------------------------- |
-| `name`         | string  | required | Display name (shown in widget and pane title)                           |
-| `task`         | string  | required | Task prompt for the sub-agent                                           |
-| `agent`        | string  | —        | Load defaults from agent definition                                     |
-| `fork`         | boolean | `false`  | Force the full-context fork mode for this spawn, overriding any agent `session-mode` frontmatter |
-| `model`        | string  | —        | Override agent's default model                                          |
-| `systemPrompt` | string  | —        | Append to system prompt                                                 |
-| `skills`       | string  | —        | Comma-separated skill names                                             |
-| `tools`        | string  | —        | Comma-separated tool names                                              |
-| `cwd`          | string  | —        | Working directory for the sub-agent (see [Role Folders](#role-folders)) |
+| Parameter              | Type    | Default        | Description                                                                                       |
+| ---------------------- | ------- | -------------- | ------------------------------------------------------------------------------------------------- |
+| `name`                 | string  | required       | Display name (shown in widget and pane title)                                                     |
+| `task`                 | string  | required       | Task prompt for the sub-agent                                                                     |
+| `agent`                | string  | —              | Load defaults from agent definition                                                               |
+| `fork`                 | boolean | `false`        | Force the full-context fork mode for this spawn, overriding any agent `session-mode` frontmatter  |
+| `model`                | string  | —              | Override agent's default model                                                                    |
+| `systemPrompt`         | string  | —              | Append to system prompt                                                                           |
+| `skills`               | string  | —              | Comma-separated skill names                                                                       |
+| `tools`                | string  | —              | Comma-separated tool names                                                                        |
+| `cwd`                  | string  | —              | Working directory for the sub-agent (see [Role Folders](#role-folders))                           |
+| `statusCadenceSeconds` | number  | config default | Idle-time window for status classification (has a minimum floor)                                  |
+
+---
+
+## Interrupting a running subagent
+
+Use `subagent_interrupt` to cancel the active turn of a running Pi-backed subagent:
+
+```typescript
+subagent_interrupt({ id: "abcd1234" });
+// or
+subagent_interrupt({ name: "Scout" });
+```
+
+This sends Escape to the child pane, cancelling the in-progress model turn. The subagent session stays alive — the pane, session file, and background polling all remain intact. After the interrupt, the widget shows the child as `quiet`. If the child makes new progress later, it returns to `active`; completion, failure, and `caller_ping` still flow through normally.
+
+This is a turn-level interrupt, not a method for forcibly terminating a subagent session.
+
+> **Note:** Only Pi-backed subagents are supported. Claude-backed runs will return an error.
 
 ---
 
@@ -299,7 +362,7 @@ By default, every sub-agent can spawn further sub-agents. Control this with fron
 
 ### `spawning: false`
 
-Denies all spawning tools (`subagent`, `subagents_list`, `subagent_resume`):
+Denies all subagent lifecycle tools (`subagent`, `subagent_interrupt`, `subagents_list`, `subagent_resume`):
 
 ```yaml
 ---
@@ -401,6 +464,14 @@ Optional backend override:
 ```bash
 export PI_SUBAGENT_MUX=cmux   # or tmux, zellij, wezterm
 ```
+
+---
+
+## Acknowledgements
+
+The sub-agent status supervision and turn-only interruption features were inspired by [RepoPrompt](https://repoprompt.com/)'s sub-agent snapshot polling and run cancellation features.
+
+---
 
 ## License
 

--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,6 @@
+{
+  "status": {
+    "enabled": true,
+    "defaultCadenceSeconds": 60
+  }
+}

--- a/pi-extension/subagents/cmux.ts
+++ b/pi-extension/subagents/cmux.ts
@@ -492,14 +492,42 @@ export function sendCommand(surface: string, command: string): void {
   }
 
   if (backend === "wezterm") {
-    execFileSync("wezterm", ["cli", "send-text", "--pane-id", surface, "--no-paste", command + "\n"], {
-      encoding: "utf8",
-    });
+    execFileSync(
+      "wezterm",
+      ["cli", "send-text", "--pane-id", surface, "--no-paste", command + "\n"],
+      { encoding: "utf8" },
+    );
     return;
   }
 
   zellijActionSync(["write-chars", command], surface);
   zellijActionSync(["write", "13"], surface);
+}
+
+/**
+ * Send one Escape keypress to an active pane.
+ */
+export function sendEscape(surface: string): void {
+  const backend = requireMuxBackend();
+
+  if (backend === "cmux") {
+    execFileSync("cmux", ["send", "--surface", surface, "\u001b"], { encoding: "utf8" });
+    return;
+  }
+
+  if (backend === "tmux") {
+    execFileSync("tmux", ["send-keys", "-t", surface, "Escape"], { encoding: "utf8" });
+    return;
+  }
+
+  if (backend === "wezterm") {
+    execFileSync("wezterm", ["cli", "send-text", "--pane-id", surface, "--no-paste", "\u001b"], {
+      encoding: "utf8",
+    });
+    return;
+  }
+
+  zellijActionSync(["write", "27"], surface);
 }
 
 /**

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -21,6 +21,8 @@ import {
   sendLongCommand,
   pollForExit,
   closeSurface,
+  getMuxBackend,
+  sendEscape,
   shellEscape,
   renameCurrentTab,
   renameWorkspace,
@@ -28,14 +30,29 @@ import {
 } from "./cmux.ts";
 import {
   findLastAssistantMessage,
+  getEntryCount,
   getNewEntries,
   seedSubagentSessionFile,
 } from "./session.ts";
+import {
+  type StatusSnapshot,
+  type SubagentStatusState,
+  advanceStatusState,
+  capStatusLines,
+  createStatusState,
+  forceStatusQuiet,
+  formatStatusAggregate,
+  formatTransitionLine,
+  observeStatus,
+  loadStatusConfig,
+  resolveStatusCadenceMs,
+} from "./status.ts";
 
 // Survive /reload: clear timers and abort poll loops from the previous module load.
 // /reload re-imports this file, giving fresh module-level state, but closures from
 // the old module keep running. See https://github.com/HazAT/pi-interactive-subagents/issues/5
 const WIDGET_INTERVAL_KEY = Symbol.for("pi-subagents/widget-interval");
+const STATUS_INTERVAL_KEY = Symbol.for("pi-subagents/status-interval");
 const POLL_ABORT_KEY = Symbol.for("pi-subagents/poll-abort-controller");
 
 {
@@ -43,6 +60,11 @@ const POLL_ABORT_KEY = Symbol.for("pi-subagents/poll-abort-controller");
   if (prevInterval) {
     clearInterval(prevInterval);
     (globalThis as any)[WIDGET_INTERVAL_KEY] = null;
+  }
+  const prevStatusInterval = (globalThis as any)[STATUS_INTERVAL_KEY];
+  if (prevStatusInterval) {
+    clearInterval(prevStatusInterval);
+    (globalThis as any)[STATUS_INTERVAL_KEY] = null;
   }
   const prevAbort = (globalThis as any)[POLL_ABORT_KEY] as AbortController | undefined;
   if (prevAbort) prevAbort.abort();
@@ -90,6 +112,13 @@ const SubagentParams = Type.Object({
         "Resume a previous Claude Code session by its ID. Loads the conversation history and continues where it left off. The session ID is returned in details of every claude tool call. Use this to retry cancelled runs or ask follow-up questions.",
     }),
   ),
+  statusCadenceSeconds: Type.Optional(
+    Type.Integer({
+      minimum: 1,
+      description:
+        "Optional per-run idle-time window in seconds for active/quiet/stalled classification. Lower values are clamped to a safe minimum.",
+    }),
+  ),
 });
 
 type SubagentSessionMode = "standalone" | "lineage-only" | "fork";
@@ -123,7 +152,12 @@ interface ListedAgentDefinition extends AgentDefinition {
 }
 
 /** Tools that are gated by `spawning: false` */
-const SPAWNING_TOOLS = new Set(["subagent", "subagents_list", "subagent_resume"]);
+const SPAWNING_TOOLS = new Set([
+  "subagent",
+  "subagent_interrupt",
+  "subagents_list",
+  "subagent_resume",
+]);
 
 /**
  * Resolve the effective set of denied tool names from agent defaults.
@@ -354,16 +388,42 @@ function formatBytes(bytes: number): string {
   return `${mb.toFixed(1)}MB`;
 }
 
-/**
- * Try to find and measure a specific session file, or discover
- * the right one from new files in the session directory.
- *
- * When `trackedFile` is provided, measures that file directly.
- * Otherwise scans for new files not in `existingFiles` or `excludeFiles`.
- *
- * Returns { file, entries, bytes } — `file` is the path that was measured,
- * so callers can lock onto it for subsequent calls.
- */
+const statusConfig = loadStatusConfig();
+
+function readSessionProgress(sessionFile: string): { entries: number; bytes: number } | null {
+  if (!existsSync(sessionFile)) return null;
+  const stat = statSync(sessionFile);
+  return {
+    entries: getEntryCount(sessionFile),
+    bytes: stat.size,
+  };
+}
+
+function buildWidgetRightLabel(agent: RunningSubagent, snapshot: StatusSnapshot): string {
+  if (snapshot.kind === "starting") return " starting… ";
+  if (snapshot.kind === "running") return ` running ${snapshot.elapsedText} `;
+  if (snapshot.kind === "active") {
+    if (agent.entries != null && agent.bytes != null) {
+      return ` active · ${agent.entries} msgs `;
+    }
+    return " active ";
+  }
+  return ` ${snapshot.kind} ${snapshot.idleText} `;
+}
+
+function resolveResultPresentation(
+  result: Pick<SubagentResult, "exitCode" | "elapsed" | "summary" | "sessionFile">,
+  name: string,
+): string {
+  const sessionRef = result.sessionFile
+    ? `\n\nSession: ${result.sessionFile}\nResume: pi --session ${result.sessionFile}`
+    : "";
+
+  return result.exitCode !== 0
+    ? `Sub-agent "${name}" failed (exit code ${result.exitCode}).\n\n${result.summary}${sessionRef}`
+    : `Sub-agent "${name}" completed (${formatElapsed(result.elapsed)}).\n\n${result.summary}${sessionRef}`;
+}
+
 /**
  * Result from running a single subagent.
  */
@@ -372,7 +432,7 @@ interface SubagentResult {
   task: string;
   summary: string;
   sessionFile?: string;
-  claudeSessionId?: string;  // For Claude Code resume capability
+  claudeSessionId?: string;
   exitCode: number;
   elapsed: number;
   error?: string;
@@ -396,6 +456,7 @@ interface RunningSubagent {
   abortController?: AbortController;
   cli?: string;
   sentinelFile?: string;
+  statusState: SubagentStatusState;
 }
 
 /** All currently running subagents, keyed by id. */
@@ -408,6 +469,9 @@ let latestCtx: ExtensionContext | null = null;
 
 /** Interval timer for widget re-renders. */
 let widgetInterval: ReturnType<typeof setInterval> | null = null;
+
+/** Interval timer for status transition checks. */
+let statusInterval: ReturnType<typeof setInterval> | null = null;
 
 function formatElapsedMMSS(startTime: number): string {
   const seconds = Math.floor((Date.now() - startTime) / 1000);
@@ -487,8 +551,10 @@ function renderSubagentWidgetLines(agents: RunningSubagent[], width: number): st
     const elapsed = formatElapsedMMSS(agent.startTime);
     const agentTag = agent.agent ? ` (${agent.agent})` : "";
     const left = ` ${elapsed}  ${agent.name}${agentTag} `;
-    const right =
-      agent.entries != null && agent.bytes != null
+    const snapshot = advanceStatusState(agent.statusState, Date.now()).snapshot;
+    const right = statusConfig.enabled
+      ? buildWidgetRightLabel(agent, snapshot)
+      : agent.entries != null && agent.bytes != null
         ? ` ${agent.entries} msgs (${formatBytes(agent.bytes)}) `
         : agent.cli === "claude"
           ? " running… "
@@ -560,6 +626,158 @@ function buildPiPromptArgs(params: {
   ];
 }
 
+function isIgnorableSessionProgressError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === "ENOENT" || code === "EBUSY";
+}
+
+function observeRunningSubagent(running: RunningSubagent, observedAt = Date.now()) {
+  if (running.cli === "claude") return;
+
+  try {
+    const progress = readSessionProgress(running.sessionFile);
+    if (!progress) return;
+
+    running.entries = progress.entries;
+    running.bytes = progress.bytes;
+    running.statusState = observeStatus(running.statusState, progress, observedAt);
+  } catch (error) {
+    // Ignore transient session-file races while the child is starting or appending.
+    // Unexpected errors should still fail fast.
+    if (!isIgnorableSessionProgressError(error)) throw error;
+  }
+}
+
+function resolveInterruptTarget(params: { id?: string; name?: string }):
+  | { running: RunningSubagent }
+  | { error: string } {
+  const requestedId = params.id?.trim();
+  if (requestedId) {
+    const running = runningSubagents.get(requestedId);
+    return running ? { running } : { error: `No running subagent with id "${requestedId}".` };
+  }
+
+  const requestedName = params.name?.trim();
+  if (!requestedName) {
+    return { error: "Provide a running subagent id or exact display name." };
+  }
+
+  const matches = Array.from(runningSubagents.values()).filter((running) => running.name === requestedName);
+  if (matches.length === 1) return { running: matches[0] };
+  if (matches.length === 0) {
+    return { error: `No running subagent named "${requestedName}".` };
+  }
+
+  const candidates = matches.map((running) => `${running.name} [${running.id}]`).join(", ");
+  return { error: `Ambiguous subagent name "${requestedName}". Matches: ${candidates}` };
+}
+
+function requestSubagentInterrupt(
+  running: RunningSubagent,
+  sendEscapeKey: (surface: string) => void = sendEscape,
+): { ok: true } | { error: string } {
+  try {
+    sendEscapeKey(running.surface);
+    return { ok: true };
+  } catch (error: any) {
+    const backend = getMuxBackend() ?? "unknown";
+    return {
+      error:
+        `Failed to send Escape to subagent "${running.name}" via ${backend}: ` +
+        `${error?.message ?? String(error)}`,
+    };
+  }
+}
+
+function handleSubagentInterrupt(
+  params: { id?: string; name?: string },
+  sendEscapeKey: (surface: string) => void = sendEscape,
+) {
+  const resolved = resolveInterruptTarget(params);
+  if ("error" in resolved) {
+    return {
+      content: [{ type: "text" as const, text: resolved.error }],
+      details: { error: resolved.error },
+    };
+  }
+
+  const running = resolved.running;
+  if (running.cli === "claude") {
+    return {
+      content: [{
+        type: "text" as const,
+        text:
+          "Turn-only Escape interrupt is currently supported only for Pi-backed subagents. Claude-backed semantics have not been verified yet.",
+      }],
+      details: { error: "claude interrupt unsupported", id: running.id, name: running.name },
+    };
+  }
+
+  const interruption = requestSubagentInterrupt(running, sendEscapeKey);
+  if ("error" in interruption) {
+    return {
+      content: [{ type: "text" as const, text: interruption.error }],
+      details: { error: interruption.error, id: running.id, name: running.name },
+    };
+  }
+
+  running.statusState = forceStatusQuiet(running.statusState, Date.now());
+  updateWidget();
+
+  return {
+    content: [{ type: "text" as const, text: `Interrupt requested for subagent "${running.name}".` }],
+    details: { id: running.id, name: running.name, status: "interrupt_requested" },
+  };
+}
+
+function startStatusRefresh(pi: ExtensionAPI) {
+  if (!statusConfig.enabled || statusInterval) return;
+
+  statusInterval = setInterval(() => {
+    if (runningSubagents.size === 0) {
+      if (statusInterval) {
+        clearInterval(statusInterval);
+        statusInterval = null;
+        (globalThis as any)[STATUS_INTERVAL_KEY] = null;
+      }
+      return;
+    }
+
+    const transitionLines: string[] = [];
+    const now = Date.now();
+    let shouldRefreshWidget = false;
+
+    for (const running of runningSubagents.values()) {
+      const { nextState, snapshot, transition } = advanceStatusState(running.statusState, now);
+      if (nextState.currentKind !== running.statusState.currentKind) {
+        shouldRefreshWidget = true;
+      }
+      running.statusState = nextState;
+
+      if (transition) {
+        transitionLines.push(formatTransitionLine(running.name, snapshot, transition));
+      }
+    }
+
+    if (shouldRefreshWidget) updateWidget();
+
+    if (transitionLines.length > 0) {
+      const capped = capStatusLines(transitionLines, statusConfig.lineLimit);
+      pi.sendMessage(
+        {
+          customType: "subagent_status",
+          content: formatStatusAggregate(transitionLines, statusConfig.lineLimit),
+          display: true,
+          details: { lines: capped.visibleLines, overflow: capped.overflow },
+        },
+        { triggerTurn: true, deliverAs: "steer" },
+      );
+    }
+  }, 1000);
+
+  (globalThis as any)[STATUS_INTERVAL_KEY] = statusInterval;
+}
+
 export const __test__ = {
   borderLine,
   getShellReadyDelayMs,
@@ -569,6 +787,15 @@ export const __test__ = {
   resolveEffectiveSessionMode,
   resolveLaunchBehavior,
   buildPiPromptArgs,
+  buildWidgetRightLabel,
+  isIgnorableSessionProgressError,
+  readSessionProgress,
+  resolveDenyTools,
+  resolveInterruptTarget,
+  requestSubagentInterrupt,
+  handleSubagentInterrupt,
+  resolveResultPresentation,
+  runningSubagents,
 };
 
 function startWidgetRefresh() {
@@ -629,6 +856,44 @@ async function launchSubagent(
     await new Promise<void>((resolve) => setTimeout(resolve, getShellReadyDelayMs()));
   }
 
+  const launchBehavior = resolveLaunchBehavior(params, agentDefs);
+  const statusCadenceMs = resolveStatusCadenceMs(statusConfig, params.statusCadenceSeconds);
+
+  if (launchBehavior.seededSessionMode) {
+    seedSubagentSessionFile({
+      mode: launchBehavior.seededSessionMode,
+      parentSessionFile: sessionFile,
+      childSessionFile: subagentSessionFile,
+      childCwd: targetCwdForSession,
+    });
+  }
+
+  const initialProgress = readSessionProgress(subagentSessionFile);
+  const { inheritsConversationContext } = launchBehavior;
+
+  // Build the task message
+  // Only full-context fork mode inherits prior conversation state.
+  // Blank-session modes need the wrapper instructions and artifact-backed handoff.
+  const modeHint = agentDefs?.autoExit
+    ? "Complete your task autonomously."
+    : "Complete your task. When finished, call the subagent_done tool. The user can interact with you at any time.";
+  const summaryInstruction = agentDefs?.autoExit
+    ? "Your FINAL assistant message should summarize what you accomplished."
+    : "Your FINAL assistant message (before calling subagent_done or before the user exits) should summarize what you accomplished.";
+  const denySet = resolveDenyTools(agentDefs);
+  const agentType = params.agent ?? params.name;
+  const tabTitleInstruction = denySet.has("set_tab_title")
+    ? ""
+    : `As your FIRST action, set the tab title using set_tab_title. ` +
+      `The title MUST start with [${agentType}] followed by a short description of your current task. ` +
+      `Example: "[${agentType}] Analyzing auth module". Keep it concise.`;
+  const identity = agentDefs?.body ?? params.systemPrompt ?? null;
+  const systemPromptMode = agentDefs?.systemPromptMode;
+  const identityInSystemPrompt = systemPromptMode && identity;
+  const roleBlock = identity && !identityInSystemPrompt ? `\n\n${identity}` : "";
+  const fullTask = inheritsConversationContext
+    ? params.task
+    : `${roleBlock}\n\n${modeHint}\n\n${tabTitleInstruction}\n\n${params.task}\n\n${summaryInstruction}`;
   // ── Claude Code CLI path ──
   if (agentDefs?.cli === "claude") {
     const sentinelFile = `/tmp/pi-claude-${id}-done`;
@@ -691,45 +956,18 @@ async function launchSubagent(
       launchScriptFile,
       cli: "claude",
       sentinelFile,
+      statusState: createStatusState({
+        source: "claude",
+        startTimeMs: startTime,
+        cadenceMs: statusCadenceMs,
+      }),
     };
 
     runningSubagents.set(id, running);
     return running;
   }
 
-  // ── Pi CLI path (existing, unchanged) ──
-
-  const launchBehavior = resolveLaunchBehavior(params, agentDefs);
-
-  if (launchBehavior.seededSessionMode) {
-    seedSubagentSessionFile({
-      mode: launchBehavior.seededSessionMode,
-      parentSessionFile: sessionFile,
-      childSessionFile: subagentSessionFile,
-      childCwd: targetCwdForSession,
-    });
-  }
-
-  const { inheritsConversationContext } = launchBehavior;
-
-  // Build the task message.
-  // Only full-context fork mode inherits prior conversation state; blank-session
-  // modes need the wrapper instructions and artifact-backed handoff.
-  const modeHint = agentDefs?.autoExit
-    ? "Complete your task autonomously."
-    : "Complete your task. When finished, call the subagent_done tool. The user can interact with you at any time.";
-  const summaryInstruction = agentDefs?.autoExit
-    ? "Your FINAL assistant message should summarize what you accomplished."
-    : "Your FINAL assistant message (before calling subagent_done or before the user exits) should summarize what you accomplished.";
-  const denySet = resolveDenyTools(agentDefs);
-
-  const identity = agentDefs?.body ?? params.systemPrompt ?? null;
-  const systemPromptMode = agentDefs?.systemPromptMode;
-  const identityInSystemPrompt = systemPromptMode && identity;
-  const roleBlock = identity && !identityInSystemPrompt ? `\n\n${identity}` : "";
-  const fullTask = inheritsConversationContext
-    ? params.task
-    : `${roleBlock}\n\n${modeHint}\n\n${params.task}\n\n${summaryInstruction}`;
+  // ── Pi CLI path ──
 
   // Build pi command
   const parts: string[] = ["pi"];
@@ -859,6 +1097,15 @@ async function launchSubagent(
     startTime,
     sessionFile: subagentSessionFile,
     launchScriptFile,
+    entries: initialProgress?.entries,
+    bytes: initialProgress?.bytes,
+    statusState: createStatusState({
+      source: "pi",
+      startTimeMs: startTime,
+      cadenceMs: statusCadenceMs,
+      baselineEntries: initialProgress?.entries,
+      baselineBytes: initialProgress?.bytes,
+    }),
   };
 
   runningSubagents.set(id, running);
@@ -903,16 +1150,7 @@ async function watchSubagent(
       sessionFile,
       sentinelFile: running.sentinelFile,
       onTick() {
-        if (running.cli !== "claude") {
-          try {
-            if (existsSync(sessionFile)) {
-              const stat = statSync(sessionFile);
-              const raw = readFileSync(sessionFile, "utf8");
-              running.entries = raw.split("\n").filter((l) => l.trim()).length;
-              running.bytes = stat.size;
-            }
-          } catch {}
-        }
+        observeRunningSubagent(running);
       },
     });
 
@@ -973,7 +1211,15 @@ async function watchSubagent(
     closeSurface(surface);
     runningSubagents.delete(running.id);
 
-    return { name, task, summary, sessionFile, exitCode: result.exitCode, elapsed, ping: result.ping };
+    return {
+      name,
+      task,
+      summary,
+      sessionFile,
+      exitCode: result.exitCode,
+      elapsed,
+      ping: result.ping,
+    };
   } catch (err: any) {
     try {
       closeSurface(surface);
@@ -988,6 +1234,7 @@ async function watchSubagent(
         exitCode: 1,
         elapsed: Math.floor((Date.now() - startTime) / 1000),
         error: "cancelled",
+        sessionFile,
       };
     }
     return {
@@ -1013,6 +1260,11 @@ export default function subagentsExtension(pi: ExtensionAPI) {
       clearInterval(widgetInterval);
       widgetInterval = null;
       (globalThis as any)[WIDGET_INTERVAL_KEY] = null;
+    }
+    if (statusInterval) {
+      clearInterval(statusInterval);
+      statusInterval = null;
+      (globalThis as any)[STATUS_INTERVAL_KEY] = null;
     }
     const moduleAbort = (globalThis as any)[POLL_ABORT_KEY] as AbortController | undefined;
     if (moduleAbort) moduleAbort.abort();
@@ -1091,8 +1343,9 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         const watcherAbort = new AbortController();
         running.abortController = watcherAbort;
 
-        // Start widget refresh when first agent launches
+        // Start widget refresh and status supervision when the first agent launches
         startWidgetRefresh();
+        startStatusRefresh(pi);
 
         // Fire-and-forget: start watching in background
         watchSubagent(running, watcherAbort.signal)
@@ -1119,18 +1372,12 @@ export default function subagentsExtension(pi: ExtensionAPI) {
               return;
             }
 
-            const sessionRef = result.sessionFile
-              ? `\n\nSession: ${result.sessionFile}\nResume: pi --session ${result.sessionFile}`
-              : "";
-            const content =
-              result.exitCode !== 0
-                ? `Sub-agent "${running.name}" failed (exit code ${result.exitCode}).\n\n${result.summary}${sessionRef}`
-                : `Sub-agent "${running.name}" completed (${formatElapsed(result.elapsed)}).\n\n${result.summary}${sessionRef}`;
+            const presentation = resolveResultPresentation(result, running.name);
 
             pi.sendMessage(
               {
                 customType: "subagent_result",
-                content,
+                content: presentation,
                 display: true,
                 details: {
                   name: running.name,
@@ -1178,6 +1425,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
             sessionFile: running.sessionFile,
             launchScriptFile: running.launchScriptFile,
             status: "started",
+            statusCadenceSeconds: params.statusCadenceSeconds,
           },
         };
       },
@@ -1185,8 +1433,15 @@ export default function subagentsExtension(pi: ExtensionAPI) {
       renderCall(args, theme) {
         const agent = args.agent ? theme.fg("dim", ` (${args.agent})`) : "";
         const cwdHint = args.cwd ? theme.fg("dim", ` in ${args.cwd}`) : "";
+        const cadenceHint = args.statusCadenceSeconds
+          ? theme.fg("dim", ` · idle window ${args.statusCadenceSeconds}s`)
+          : "";
         let text =
-          "▸ " + theme.fg("toolTitle", theme.bold(args.name ?? "(unnamed)")) + agent + cwdHint;
+          "▸ " +
+          theme.fg("toolTitle", theme.bold(args.name ?? "(unnamed)")) +
+          agent +
+          cwdHint +
+          cadenceHint;
 
         // Show a one-line task preview. renderCall is called repeatedly as the
         // LLM generates tool arguments, so args.task grows token by token.
@@ -1224,6 +1479,58 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         }
 
         // Fallback (shouldn't happen)
+        const text = typeof result.content?.[0]?.text === "string" ? result.content[0].text : "";
+        return new Text(theme.fg("dim", text), 0, 0);
+      },
+    });
+
+  // ── subagent_interrupt tool ──
+  if (shouldRegister("subagent_interrupt"))
+    pi.registerTool({
+      name: "subagent_interrupt",
+      label: "Interrupt Subagent",
+      description:
+        "Send Escape to the active turn of a currently running Pi-backed subagent. " +
+        "The child pane, session, watcher, and running entry remain alive; this returns only a local acknowledgement " +
+        "and does not emit a subagent_result solely because of this request.",
+      promptSnippet:
+        "Send Escape to the active turn of a currently running Pi-backed subagent. " +
+        "The child pane, session, watcher, and running entry remain alive; this returns only a local acknowledgement " +
+        "and does not emit a subagent_result solely because of this request.",
+      parameters: Type.Object({
+        id: Type.Optional(Type.String({ description: "Exact running subagent id" })),
+        name: Type.Optional(Type.String({ description: "Exact running subagent display name" })),
+      }),
+
+      async execute(_toolCallId, params) {
+        return handleSubagentInterrupt(params);
+      },
+
+      renderCall(args, theme) {
+        const target = args.id ? `${args.id}` : args.name ?? "(unknown)";
+        return new Text(
+          theme.fg("accent", "▸") +
+            " " +
+            theme.fg("toolTitle", theme.bold(target)) +
+            theme.fg("dim", " — interrupt turn"),
+          0,
+          0,
+        );
+      },
+
+      renderResult(result, _opts, theme) {
+        const details = result.details as any;
+        if (details?.status === "interrupt_requested") {
+          return new Text(
+            theme.fg("accent", "▸") +
+              " " +
+              theme.fg("toolTitle", theme.bold(details.name ?? details.id ?? "subagent")) +
+              theme.fg("dim", " — interrupt requested"),
+            0,
+            0,
+          );
+        }
+
         const text = typeof result.content?.[0]?.text === "string" ? result.content[0].text : "";
         return new Text(theme.fg("dim", text), 0, 0);
       },
@@ -1310,12 +1617,25 @@ export default function subagentsExtension(pi: ExtensionAPI) {
             description: "Optional message to send after resuming (e.g. follow-up instructions)",
           }),
         ),
+        statusCadenceSeconds: Type.Optional(
+          Type.Integer({
+            minimum: 1,
+            description:
+              "Optional per-run idle-time window in seconds for active/quiet/stalled classification in this resumed run. Lower values are clamped to a safe minimum.",
+          }),
+        ),
       }),
 
       renderCall(args, theme) {
         const name = args.name ?? "Resume";
+        const cadenceHint = args.statusCadenceSeconds
+          ? theme.fg("dim", ` · idle window ${args.statusCadenceSeconds}s`)
+          : "";
         const text =
-          "▸ " + theme.fg("toolTitle", theme.bold(name)) + theme.fg("dim", " — resuming session");
+          "▸ " +
+          theme.fg("toolTitle", theme.bold(name)) +
+          theme.fg("dim", " — resuming session") +
+          cadenceHint;
         return new Text(text, 0, 0);
       },
 
@@ -1361,6 +1681,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 
         const surface = createSurface(name);
         await new Promise<void>((resolve) => setTimeout(resolve, getShellReadyDelayMs()));
+        const statusCadenceMs = resolveStatusCadenceMs(statusConfig, params.statusCadenceSeconds);
 
         // Build pi resume command
         const parts = ["pi", "--session", shellEscape(params.sessionPath)];
@@ -1424,6 +1745,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 
         // Register as a running subagent for widget tracking
         const id = Math.random().toString(16).slice(2, 10);
+        const initialProgress = readSessionProgress(params.sessionPath);
         const running: RunningSubagent = {
           id,
           name,
@@ -1432,9 +1754,19 @@ export default function subagentsExtension(pi: ExtensionAPI) {
           startTime,
           sessionFile: params.sessionPath,
           launchScriptFile,
+          entries: initialProgress?.entries,
+          bytes: initialProgress?.bytes,
+          statusState: createStatusState({
+            source: "pi",
+            startTimeMs: startTime,
+            cadenceMs: statusCadenceMs,
+            baselineEntries: entryCountBefore,
+            baselineBytes: initialProgress?.bytes,
+          }),
         };
         runningSubagents.set(id, running);
         startWidgetRefresh();
+        startStatusRefresh(pi);
 
         // Fire-and-forget watcher
         const watcherAbort = new AbortController();
@@ -1463,17 +1795,19 @@ export default function subagentsExtension(pi: ExtensionAPI) {
             }
 
             const allEntries = getNewEntries(params.sessionPath, entryCountBefore);
-            const summary =
-              findLastAssistantMessage(allEntries) ??
+            const summary = findLastAssistantMessage(allEntries) ??
               (result.exitCode !== 0
                 ? `Resumed session exited with code ${result.exitCode}`
                 : "Resumed session exited without new output");
-            const sessionRef = `\n\nSession: ${params.sessionPath}\nResume: pi --session ${params.sessionPath}`;
+            const presentation = resolveResultPresentation(
+              { ...result, summary, sessionFile: params.sessionPath },
+              name,
+            );
 
             pi.sendMessage(
               {
                 customType: "subagent_result",
-                content: `${summary}${sessionRef}`,
+                content: presentation,
                 display: true,
                 details: {
                   name,
@@ -1507,6 +1841,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
             sessionPath: params.sessionPath,
             launchScriptFile,
             status: "started",
+            statusCadenceSeconds: params.statusCadenceSeconds,
           },
         };
       },
@@ -1564,12 +1899,15 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         const name = details.name ?? "subagent";
         const exitCode = details.exitCode ?? 0;
         const elapsed = details.elapsed != null ? formatElapsed(details.elapsed) : "?";
-        const bgFn =
-          exitCode === 0
-            ? (text: string) => theme.bg("toolSuccessBg", text)
-            : (text: string) => theme.bg("toolErrorBg", text);
-        const icon = exitCode === 0 ? theme.fg("success", "✓") : theme.fg("error", "✗");
-        const status = exitCode === 0 ? "completed" : `failed (exit ${exitCode})`;
+        const bgFn = exitCode === 0
+          ? (text: string) => theme.bg("toolSuccessBg", text)
+          : (text: string) => theme.bg("toolErrorBg", text);
+        const icon = exitCode === 0
+          ? theme.fg("success", "✓")
+          : theme.fg("error", "✗");
+        const status = exitCode === 0
+          ? "completed"
+          : `failed (exit ${exitCode})`;
         const agentTag = details.agent ? theme.fg("dim", ` (${details.agent})`) : "";
 
         const header = `${icon} ${theme.fg("toolTitle", theme.bold(name))}${agentTag} ${theme.fg("dim", "—")} ${status} ${theme.fg("dim", `(${elapsed})`)}`;
@@ -1613,6 +1951,35 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 
         // Render via Box for background + padding, with blank line above for separation
         const box = new Box(1, 1, bgFn);
+        box.addChild(new Text(contentLines.join("\n"), 0, 0));
+        return ["", ...box.render(width)];
+      },
+    };
+  });
+
+  // ── subagent_status message renderer ──
+  pi.registerMessageRenderer("subagent_status", (message, options, theme) => {
+    const details = message.details as any;
+    const lines = Array.isArray(details?.lines) ? details.lines : [];
+    const overflow = typeof details?.overflow === "number" ? details.overflow : 0;
+    if (lines.length === 0 && overflow === 0) return undefined;
+
+    return {
+      render(width: number): string[] {
+        const lineWidth = Math.max(0, width - 6);
+        const contentLines = [
+          `${theme.fg("accent", "•")} ${theme.fg("toolTitle", theme.bold("Subagent status"))}`,
+          ...lines.map((line: string) => theme.fg("dim", truncateToWidth(line, lineWidth))),
+        ];
+
+        if (overflow > 0) {
+          contentLines.push(theme.fg("muted", `+${overflow} more running.`));
+        }
+        if (!options.expanded) {
+          contentLines.push(theme.fg("muted", keyHint("app.tools.expand", "to expand")));
+        }
+
+        const box = new Box(1, 1, (text: string) => theme.bg("customMessageBg", text));
         box.addChild(new Text(contentLines.join("\n"), 0, 0));
         return ["", ...box.render(width)];
       },

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -881,19 +881,13 @@ async function launchSubagent(
     ? "Your FINAL assistant message should summarize what you accomplished."
     : "Your FINAL assistant message (before calling subagent_done or before the user exits) should summarize what you accomplished.";
   const denySet = resolveDenyTools(agentDefs);
-  const agentType = params.agent ?? params.name;
-  const tabTitleInstruction = denySet.has("set_tab_title")
-    ? ""
-    : `As your FIRST action, set the tab title using set_tab_title. ` +
-      `The title MUST start with [${agentType}] followed by a short description of your current task. ` +
-      `Example: "[${agentType}] Analyzing auth module". Keep it concise.`;
   const identity = agentDefs?.body ?? params.systemPrompt ?? null;
   const systemPromptMode = agentDefs?.systemPromptMode;
   const identityInSystemPrompt = systemPromptMode && identity;
   const roleBlock = identity && !identityInSystemPrompt ? `\n\n${identity}` : "";
   const fullTask = inheritsConversationContext
     ? params.task
-    : `${roleBlock}\n\n${modeHint}\n\n${tabTitleInstruction}\n\n${params.task}\n\n${summaryInstruction}`;
+    : `${roleBlock}\n\n${modeHint}\n\n${params.task}\n\n${summaryInstruction}`;
   // ── Claude Code CLI path ──
   if (agentDefs?.cli === "claude") {
     const sentinelFile = `/tmp/pi-claude-${id}-done`;

--- a/pi-extension/subagents/status.ts
+++ b/pi-extension/subagents/status.ts
@@ -1,0 +1,398 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const DEFAULT_STATUS_CADENCE_MS = 60_000;
+export const MIN_STATUS_CADENCE_MS = 10_000;
+export const MIN_STALLED_MS = 30_000;
+export const STALLED_MULTIPLIER = 3;
+export const DEFAULT_STATUS_LINE_LIMIT = 4;
+export const MAX_STATUS_NAME_LENGTH = 72;
+export const MAX_STATUS_LINE_LENGTH = 120;
+
+const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const DEFAULT_STATUS_CONFIG_PATH = join(PACKAGE_ROOT, "config.json");
+const STATUS_CONFIG_EXAMPLE_PATH = join(PACKAGE_ROOT, "config.json.example");
+
+export type SubagentStatusKind = "starting" | "active" | "quiet" | "stalled" | "running";
+export type SubagentStatusSource = "pi" | "claude";
+export type SubagentStatusTransition = "stalled" | "recovered" | null;
+
+export interface StatusConfig {
+  enabled: boolean;
+  defaultCadenceMs: number;
+  lineLimit: number;
+}
+
+export interface StatusObservation {
+  entries: number;
+  bytes: number;
+}
+
+export interface SubagentStatusState {
+  source: SubagentStatusSource;
+  startTimeMs: number;
+  cadenceMs: number;
+  baselineEntries: number | null;
+  baselineBytes: number | null;
+  observedEntries: number | null;
+  observedBytes: number | null;
+  firstObservationAtMs: number | null;
+  lastProgressAtMs: number | null;
+  // Cadence tracks classification/progress windows for local widget status.
+  // Routine status messages are intentionally not emitted.
+  lastCadenceAtMs: number;
+  lastCadenceEntries: number | null;
+  currentKind: SubagentStatusKind;
+}
+
+export interface StatusSnapshot {
+  kind: SubagentStatusKind;
+  elapsedMs: number;
+  elapsedText: string;
+  idleMs: number | null;
+  idleText: string | null;
+  progressEvents: number | null;
+}
+
+export interface CappedStatusLines {
+  visibleLines: string[];
+  overflow: number;
+}
+
+function invalidStatusConfig(source: string, message: string): never {
+  throw new Error(`Invalid subagent status config in ${source}: ${message}`);
+}
+
+function requireObject(value: unknown, source: string, fieldName: string): Record<string, unknown> {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    invalidStatusConfig(source, `${fieldName} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireBoolean(value: unknown, source: string, fieldName: string): boolean {
+  if (typeof value !== "boolean") {
+    invalidStatusConfig(source, `${fieldName} must be a boolean`);
+  }
+  return value;
+}
+
+function requirePositiveInteger(value: unknown, source: string, fieldName: string): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    invalidStatusConfig(source, `${fieldName} must be a positive integer`);
+  }
+  return value;
+}
+
+function clampCadenceMs(ms: number): number {
+  if (!Number.isFinite(ms) || ms <= 0) return DEFAULT_STATUS_CADENCE_MS;
+  return Math.max(MIN_STATUS_CADENCE_MS, Math.floor(ms));
+}
+
+function truncateText(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  if (maxLength <= 1) return text.slice(0, maxLength);
+  return `${text.slice(0, maxLength - 1)}…`;
+}
+
+export function normalizeStatusName(name: string): string {
+  const collapsed = name.replace(/\s+/g, " ").trim() || "subagent";
+  return truncateText(collapsed, MAX_STATUS_NAME_LENGTH);
+}
+
+function boundStatusLine(line: string): string {
+  return truncateText(line.replace(/\s+/g, " ").trim(), MAX_STATUS_LINE_LENGTH);
+}
+
+export function parseStatusConfig(rawConfig: unknown, source = "config.json"): StatusConfig {
+  const config = requireObject(rawConfig, source, "root");
+  const status = requireObject(config.status, source, "status");
+  const enabled = requireBoolean(status.enabled, source, "status.enabled");
+  const defaultCadenceSeconds = requirePositiveInteger(
+    status.defaultCadenceSeconds,
+    source,
+    "status.defaultCadenceSeconds",
+  );
+
+  return {
+    enabled,
+    defaultCadenceMs: clampCadenceMs(defaultCadenceSeconds * 1000),
+    lineLimit: DEFAULT_STATUS_LINE_LIMIT,
+  };
+}
+
+function readStatusConfigFile(configPath: string, examplePath: string): { sourcePath: string; rawConfig: string } {
+  try {
+    return { sourcePath: configPath, rawConfig: readFileSync(configPath, "utf8") };
+  } catch (error) {
+    const errno = error as NodeJS.ErrnoException;
+    if (errno.code !== "ENOENT") throw error;
+  }
+
+  try {
+    return { sourcePath: examplePath, rawConfig: readFileSync(examplePath, "utf8") };
+  } catch (error) {
+    const errno = error as NodeJS.ErrnoException;
+    if (errno.code === "ENOENT") {
+      throw new Error(
+        `Missing subagent status config. Expected ${configPath} or ${examplePath}.`,
+      );
+    }
+    throw error;
+  }
+}
+
+export function loadStatusConfig(
+  configPath = DEFAULT_STATUS_CONFIG_PATH,
+  examplePath = STATUS_CONFIG_EXAMPLE_PATH,
+): StatusConfig {
+  const { sourcePath, rawConfig } = readStatusConfigFile(configPath, examplePath);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawConfig) as unknown;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid JSON in subagent config ${sourcePath}: ${detail}`);
+  }
+
+  return parseStatusConfig(parsed, sourcePath);
+}
+
+export function resolveStatusCadenceMs(
+  config: StatusConfig,
+  requestedSeconds?: number,
+): number {
+  if (requestedSeconds == null) return config.defaultCadenceMs;
+  return clampCadenceMs(requestedSeconds * 1000);
+}
+
+export function getStalledAfterMs(cadenceMs: number): number {
+  return Math.max(cadenceMs * STALLED_MULTIPLIER, MIN_STALLED_MS);
+}
+
+export function formatElapsedDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  if (hours > 0) return `${hours}h ${minutes}m`;
+
+  return `${minutes}m`;
+}
+
+function isProgressIncrease(
+  previous: Pick<SubagentStatusState, "observedEntries" | "observedBytes">,
+  next: StatusObservation,
+): boolean {
+  if (previous.observedEntries == null || previous.observedBytes == null) {
+    return true;
+  }
+  return next.entries > previous.observedEntries || next.bytes > previous.observedBytes;
+}
+
+export function createStatusState(params: {
+  source: SubagentStatusSource;
+  startTimeMs: number;
+  cadenceMs: number;
+  baselineEntries?: number | null;
+  baselineBytes?: number | null;
+}): SubagentStatusState {
+  const initialKind = params.source === "claude" ? "running" : "starting";
+  return {
+    source: params.source,
+    startTimeMs: params.startTimeMs,
+    cadenceMs: params.cadenceMs,
+    baselineEntries: params.baselineEntries ?? null,
+    baselineBytes: params.baselineBytes ?? null,
+    observedEntries: params.baselineEntries ?? null,
+    observedBytes: params.baselineBytes ?? null,
+    firstObservationAtMs: params.baselineEntries != null ? params.startTimeMs : null,
+    lastProgressAtMs: null,
+    lastCadenceAtMs: params.startTimeMs,
+    lastCadenceEntries: params.baselineEntries ?? null,
+    currentKind: initialKind,
+  };
+}
+
+export function observeStatus(
+  state: SubagentStatusState,
+  observation: StatusObservation,
+  now: number,
+): SubagentStatusState {
+  const progressIncrease = isProgressIncrease(state, observation);
+  const baselineEntries = state.baselineEntries ?? 0;
+  const baselineBytes = state.baselineBytes ?? 0;
+  const crossesBaseline = observation.entries > baselineEntries || observation.bytes > baselineBytes;
+  const shouldMarkProgress = progressIncrease && crossesBaseline;
+
+  return {
+    ...state,
+    observedEntries: observation.entries,
+    observedBytes: observation.bytes,
+    firstObservationAtMs: state.firstObservationAtMs ?? now,
+    lastProgressAtMs: shouldMarkProgress ? now : state.lastProgressAtMs,
+  };
+}
+
+export function forceStatusQuiet(state: SubagentStatusState, now: number): SubagentStatusState {
+  // The interrupt path currently applies only to Pi-backed children.
+  // Claude-backed states always classify as `running`, so accidental calls stay a no-op.
+  if (state.source === "claude") return state;
+
+  const quietIdleMs = state.cadenceMs + 1;
+  const maxQuietIdleMs = getStalledAfterMs(state.cadenceMs) - 1;
+  const forcedIdleMs = Math.min(quietIdleMs, maxQuietIdleMs);
+  const forcedProgressAtMs = now - forcedIdleMs;
+  const firstObservationAtMs =
+    state.firstObservationAtMs == null || state.firstObservationAtMs > forcedProgressAtMs
+      ? forcedProgressAtMs
+      : state.firstObservationAtMs;
+
+  return {
+    ...state,
+    firstObservationAtMs,
+    lastProgressAtMs: forcedProgressAtMs,
+    currentKind: "quiet",
+  };
+}
+
+export function classifyStatus(state: SubagentStatusState, now: number): StatusSnapshot {
+  const elapsedMs = Math.max(0, now - state.startTimeMs);
+  const elapsedText = formatElapsedDuration(elapsedMs);
+
+  if (state.source === "claude") {
+    return {
+      kind: "running",
+      elapsedMs,
+      elapsedText,
+      idleMs: null,
+      idleText: null,
+      progressEvents: null,
+    };
+  }
+
+  if (state.observedEntries == null || state.observedBytes == null) {
+    const idleStartMs = state.lastProgressAtMs ?? state.firstObservationAtMs ?? state.startTimeMs;
+    const idleMs = Math.max(0, now - idleStartMs);
+    const stalled = idleMs >= getStalledAfterMs(state.cadenceMs);
+    const hasLocalQuietMarker = state.lastProgressAtMs != null;
+    return {
+      kind: stalled ? "stalled" : hasLocalQuietMarker ? "quiet" : "starting",
+      elapsedMs,
+      elapsedText,
+      idleMs,
+      idleText: formatElapsedDuration(idleMs),
+      progressEvents: null,
+    };
+  }
+
+  const idleStartMs = state.lastProgressAtMs ?? state.firstObservationAtMs ?? state.startTimeMs;
+  const idleMs = Math.max(0, now - idleStartMs);
+  const kind = idleMs >= getStalledAfterMs(state.cadenceMs)
+    ? "stalled"
+    : state.lastProgressAtMs != null && idleMs < state.cadenceMs
+      ? "active"
+      : "quiet";
+  const progressEvents =
+    state.observedEntries != null && state.lastCadenceEntries != null
+      ? Math.max(0, state.observedEntries - state.lastCadenceEntries)
+      : null;
+
+  return {
+    kind,
+    elapsedMs,
+    elapsedText,
+    idleMs,
+    idleText: formatElapsedDuration(idleMs),
+    progressEvents,
+  };
+}
+
+export function advanceStatusState(
+  state: SubagentStatusState,
+  now: number,
+): {
+  nextState: SubagentStatusState;
+  snapshot: StatusSnapshot;
+  transition: SubagentStatusTransition;
+  cadenceElapsed: boolean;
+} {
+  const snapshot = classifyStatus(state, now);
+  const transition =
+    state.currentKind !== "stalled" && snapshot.kind === "stalled"
+      ? "stalled"
+      : state.currentKind === "stalled" && snapshot.kind === "active"
+        ? "recovered"
+        : null;
+  const cadenceElapsed = now - state.lastCadenceAtMs >= state.cadenceMs;
+
+  return {
+    snapshot,
+    transition,
+    cadenceElapsed,
+    nextState: {
+      ...state,
+      currentKind: snapshot.kind,
+      lastCadenceAtMs: cadenceElapsed ? now : state.lastCadenceAtMs,
+      lastCadenceEntries: cadenceElapsed ? state.observedEntries : state.lastCadenceEntries,
+    },
+  };
+}
+
+export function formatStatusLine(name: string, snapshot: StatusSnapshot): string {
+  const boundedName = normalizeStatusName(name);
+
+  if (snapshot.kind === "starting") {
+    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, starting.`);
+  }
+
+  if (snapshot.kind === "running") {
+    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}.`);
+  }
+
+  if (snapshot.kind === "active") {
+    const progress = snapshot.progressEvents && snapshot.progressEvents > 0
+      ? ` (+${snapshot.progressEvents} events)`
+      : "";
+    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, active${progress}.`);
+  }
+
+  return boundStatusLine(
+    `${boundedName} running ${snapshot.elapsedText}, ${snapshot.kind} ${snapshot.idleText}.`,
+  );
+}
+
+export function formatTransitionLine(
+  name: string,
+  snapshot: StatusSnapshot,
+  transition: Exclude<SubagentStatusTransition, null>,
+): string {
+  const boundedName = normalizeStatusName(name);
+
+  if (transition === "recovered") {
+    const progress = snapshot.progressEvents && snapshot.progressEvents > 0
+      ? ` (+${snapshot.progressEvents} events)`
+      : "";
+    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, recovered; active${progress}.`);
+  }
+
+  return formatStatusLine(boundedName, snapshot);
+}
+
+export function capStatusLines(lines: string[], lineLimit: number): CappedStatusLines {
+  const visibleLines = lines.slice(0, lineLimit);
+  return {
+    visibleLines,
+    overflow: Math.max(0, lines.length - visibleLines.length),
+  };
+}
+
+export function formatStatusAggregate(lines: string[], lineLimit: number): string {
+  const { visibleLines, overflow } = capStatusLines(lines, lineLimit);
+  const bulletLines = visibleLines.map((line) => `• ${line}`);
+  if (overflow > 0) bulletLines.push(`• +${overflow} more running.`);
+  return `Subagent status:\n${bulletLines.join("\n")}`;
+}

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -7,12 +7,6 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Box, Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { writeFileSync } from "node:fs";
-import {
-  isMuxAvailable,
-  muxSetupHint,
-  renameCurrentTab,
-  renameWorkspace,
-} from "./cmux.ts";
 
 export function shouldMarkUserTookOver(agentStarted: boolean): boolean {
   return agentStarted;
@@ -41,10 +35,6 @@ export function parseDeniedTools(rawValue: string | undefined): string[] {
     .split(",")
     .map((value) => value.trim())
     .filter(Boolean);
-}
-
-export function shouldRegisterSetTabTitle(deniedToolsValue: string | undefined): boolean {
-  return !parseDeniedTools(deniedToolsValue).includes("set_tab_title");
 }
 
 export default function (pi: ExtensionAPI) {
@@ -162,51 +152,6 @@ export default function (pi: ExtensionAPI) {
       renderWidget(ctx, null);
     },
   });
-
-  if (shouldRegisterSetTabTitle(deniedToolsValue)) {
-    pi.registerTool({
-      name: "set_tab_title",
-      label: "Set Tab Title",
-      description:
-        "Update the current tab/window and workspace/session title. Use to show progress during multi-phase workflows " +
-        "(e.g. planning, executing todos, reviewing). Keep titles short and informative.",
-      promptSnippet:
-        "Update the current tab/window and workspace/session title. Use to show progress during multi-phase workflows " +
-        "(e.g. planning, executing todos, reviewing). Keep titles short and informative.",
-      parameters: Type.Object({
-        title: Type.String({
-          description: "New tab title (also applied to workspace/session when supported)",
-        }),
-      }),
-      async execute(_toolCallId, params) {
-        if (!isMuxAvailable()) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Terminal multiplexer not available. ${muxSetupHint()}`,
-              },
-            ],
-            details: { error: "mux not available" },
-          };
-        }
-
-        try {
-          renameCurrentTab(params.title);
-          renameWorkspace(params.title);
-          return {
-            content: [{ type: "text", text: `Title set to: ${params.title}` }],
-            details: { title: params.title },
-          };
-        } catch (err: any) {
-          return {
-            content: [{ type: "text", text: `Failed to set title: ${err?.message}` }],
-            details: { error: err?.message },
-          };
-        }
-      },
-    });
-  }
 
   pi.registerTool({
     name: "caller_ping",

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -7,6 +7,12 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Box, Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { writeFileSync } from "node:fs";
+import {
+  isMuxAvailable,
+  muxSetupHint,
+  renameCurrentTab,
+  renameWorkspace,
+} from "./cmux.ts";
 
 export function shouldMarkUserTookOver(agentStarted: boolean): boolean {
   return agentStarted;
@@ -30,6 +36,17 @@ export function shouldAutoExitOnAgentEnd(
   return true;
 }
 
+export function parseDeniedTools(rawValue: string | undefined): string[] {
+  return (rawValue ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+export function shouldRegisterSetTabTitle(deniedToolsValue: string | undefined): boolean {
+  return !parseDeniedTools(deniedToolsValue).includes("set_tab_title");
+}
+
 export default function (pi: ExtensionAPI) {
   let toolNames: string[] = [];
   let denied: string[] = [];
@@ -38,6 +55,7 @@ export default function (pi: ExtensionAPI) {
   // Read subagent identity from env vars (set by parent orchestrator)
   const subagentName = process.env.PI_SUBAGENT_NAME ?? "";
   const subagentAgent = process.env.PI_SUBAGENT_AGENT ?? "";
+  const deniedToolsValue = process.env.PI_DENY_TOOLS;
 
   function renderWidget(ctx: { ui: { setWidget: Function } }, _theme: any) {
     ctx.ui.setWidget(
@@ -96,10 +114,7 @@ export default function (pi: ExtensionAPI) {
   pi.on("session_start", (_event, ctx) => {
     const tools = pi.getAllTools();
     toolNames = tools.map((t) => t.name).sort();
-    denied = (process.env.PI_DENY_TOOLS ?? "")
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean);
+    denied = parseDeniedTools(deniedToolsValue);
 
     renderWidget(ctx, null);
   });
@@ -147,6 +162,51 @@ export default function (pi: ExtensionAPI) {
       renderWidget(ctx, null);
     },
   });
+
+  if (shouldRegisterSetTabTitle(deniedToolsValue)) {
+    pi.registerTool({
+      name: "set_tab_title",
+      label: "Set Tab Title",
+      description:
+        "Update the current tab/window and workspace/session title. Use to show progress during multi-phase workflows " +
+        "(e.g. planning, executing todos, reviewing). Keep titles short and informative.",
+      promptSnippet:
+        "Update the current tab/window and workspace/session title. Use to show progress during multi-phase workflows " +
+        "(e.g. planning, executing todos, reviewing). Keep titles short and informative.",
+      parameters: Type.Object({
+        title: Type.String({
+          description: "New tab title (also applied to workspace/session when supported)",
+        }),
+      }),
+      async execute(_toolCallId, params) {
+        if (!isMuxAvailable()) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Terminal multiplexer not available. ${muxSetupHint()}`,
+              },
+            ],
+            details: { error: "mux not available" },
+          };
+        }
+
+        try {
+          renameCurrentTab(params.title);
+          renameWorkspace(params.title);
+          return {
+            content: [{ type: "text", text: `Title set to: ${params.title}` }],
+            details: { title: params.title },
+          };
+        } catch (err: any) {
+          return {
+            content: [{ type: "text", text: `Failed to set title: ${err?.message}` }],
+            details: { error: err?.message },
+          };
+        }
+      },
+    });
+  }
 
   pi.registerTool({
     name: "caller_ping",

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -55,6 +55,19 @@ const HARNESS_DIR = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = resolve(HARNESS_DIR, "../..");
 const TEST_AGENTS_SRC = join(HARNESS_DIR, "agents");
 
+/**
+ * Absolute path to the extension source in the working tree.
+ *
+ * Integration tests must exercise the code on the current branch — NOT the
+ * version installed as a pi-package under `~/.pi/agent/git/...` or the project
+ * mirror under `.pi/git/...`, which stays pinned to the last released tag.
+ *
+ * We force-load this file via `pi -ne -e <path>` in startPi() below so local
+ * edits are always the code under test, regardless of what pi-packages are
+ * installed on the host.
+ */
+const EXTENSION_SOURCE = join(PROJECT_ROOT, "pi-extension", "subagents", "index.ts");
+
 // ── Configuration ──
 
 /** Model used for integration tests. Override with PI_TEST_MODEL env var. */
@@ -184,9 +197,15 @@ export function startPi(
   const model = opts?.model ?? TEST_MODEL;
   const extra = opts?.extraArgs ?? "";
 
+  // Force pi to load the working-tree extension (not an installed pi-package
+  // snapshot). `-ne` disables extension auto-discovery, `-e <path>` loads the
+  // current branch's source directly. Without this, the tests silently run
+  // against whatever version is checked out under `~/.pi/agent/git/...`.
   const cmd = [
     `cd ${shellEscape(testDir)} &&`,
     `pi`,
+    `-ne`,
+    `-e ${shellEscape(EXTENSION_SOURCE)}`,
     `--model ${shellEscape(model)}`,
     extra,
     shellEscape(task),

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -30,6 +30,7 @@ import {
   readScreen,
   readScreenAsync,
   closeSurface,
+  sendEscape,
   shellEscape,
   type MuxBackend,
 } from "../../pi-extension/subagents/cmux.ts";
@@ -43,6 +44,7 @@ export {
   readScreen,
   readScreenAsync,
   closeSurface,
+  sendEscape,
   shellEscape,
 };
 export type { MuxBackend };

--- a/test/integration/mux-surface.test.ts
+++ b/test/integration/mux-surface.test.ts
@@ -25,8 +25,12 @@ import {
   readScreen,
   readScreenAsync,
   closeSurface,
+  sendEscape,
   sleep,
   uniqueId,
+  trackTempFile,
+  waitForFile,
+  waitForScreen,
   type TestEnv,
 } from "./harness.ts";
 
@@ -38,7 +42,7 @@ if (backends.length === 0) {
 }
 
 for (const backend of backends) {
-  describe(`mux-surface [${backend}]`, { timeout: 30_000 }, () => {
+  describe(`mux-surface [${backend}]`, { timeout: 60_000 }, () => {
     let prevMux: string | undefined;
     let env: TestEnv;
 
@@ -170,6 +174,35 @@ for (const backend of backends) {
       try {
         unlinkSync(filePath);
       } catch {}
+    });
+
+    it("delivers Escape as byte 27 to the target surface", async () => {
+      const surface = createTrackedSurface(env, "escape-byte-test");
+      await sleep(1000);
+
+      const marker = uniqueId();
+      const byteFile = `/tmp/pi-mux-escape-${marker}.txt`;
+      trackTempFile(env, byteFile);
+
+      const nodeProgram =
+        "const fs = require('node:fs');" +
+        "if (!process.stdin.isTTY) throw new Error('stdin is not a TTY');" +
+        "process.stdin.setRawMode(true);" +
+        "process.stdin.resume();" +
+        "process.stdout.write('ESC_READY\\n');" +
+        "process.stdin.once('data', (chunk) => {" +
+        `fs.writeFileSync(${JSON.stringify(byteFile)}, Array.from(chunk).join(','));` +
+        "process.exit(0);" +
+        "});";
+      const command = `node -e ${JSON.stringify(nodeProgram)}`;
+
+      sendLongCommand(surface, command);
+      await waitForScreen(surface, /ESC_READY/, 15_000, 50);
+
+      sendEscape(surface);
+
+      const content = await waitForFile(byteFile, 15_000, /^27$/);
+      assert.equal(content.trim(), "27");
     });
   });
 }

--- a/test/integration/subagent-lifecycle.test.ts
+++ b/test/integration/subagent-lifecycle.test.ts
@@ -109,6 +109,49 @@ for (const backend of backends) {
       }
     });
 
+    // ── In-progress stalled status ──
+
+    it("surfaces a compact stalled status before final completion", async () => {
+      const id = uniqueId();
+      const markerFile = `/tmp/pi-integ-status-${id}.txt`;
+      trackTempFile(env, markerFile);
+
+      const surface = createTrackedSurface(env, `status-${id}`);
+      await sleep(1000);
+
+      const task = [
+        `Call the subagent tool with these EXACT parameters:`,
+        `  name: "Status-${id}"`,
+        `  agent: "test-echo"`,
+        `  statusCadenceSeconds: 10`,
+        `  task: "Run this bash command: sleep 55; echo 'STATUS_${id}' > '${markerFile}'"`,
+        `Do not do anything else. Just call the subagent tool once.`,
+        `After you receive the subagent result, say STATUS_TEST_DONE.`,
+      ].join("\n");
+
+      startPi(surface, env.dir, task);
+
+      const stalledScreen = await waitForScreen(
+        surface,
+        /Subagent status[\s\S]*stalled|stalled[\s\S]*Subagent status/i,
+        PI_TIMEOUT,
+        300,
+      );
+      assert.match(stalledScreen, /Subagent status/i);
+      assert.match(stalledScreen, /stalled/i);
+
+      const content = await waitForFile(markerFile, PI_TIMEOUT, /STATUS_/);
+      assert.ok(content.includes(`STATUS_${id}`), `Marker file should contain STATUS_${id}`);
+
+      const completionScreen = await waitForScreen(
+        surface,
+        /STATUS_TEST_DONE|completed|Sub-agent.*"Status-/i,
+        PI_TIMEOUT,
+        300,
+      );
+      assert.ok(/STATUS_TEST_DONE|completed/i.test(completionScreen));
+    });
+
     // ── Parallel subagent spawn ──
 
     it("spawns two subagents in parallel and both complete", async () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -34,7 +34,7 @@ import {
   parseStatusConfig,
   resolveStatusCadenceMs,
 } from "../pi-extension/subagents/status.ts";
-import subagentDoneExtension, {
+import {
   shouldMarkUserTookOver,
   shouldAutoExitOnAgentEnd,
 } from "../pi-extension/subagents/subagent-done.ts";
@@ -964,40 +964,6 @@ describe("commands", () => {
 });
 
 describe("tool registration", () => {
-  it("does not register set_tab_title in the main session extension", () => {
-    const { api, registeredTools } = createMockExtensionApi();
-
-    (subagentsModule as any).default(api);
-
-    assert.equal(registeredTools.some((tool) => tool.name === "set_tab_title"), false);
-  });
-
-  it("registers set_tab_title in subagent sessions", () => {
-    const previousDeniedTools = process.env.PI_DENY_TOOLS;
-
-    try {
-      delete process.env.PI_DENY_TOOLS;
-      const { api, registeredTools } = createMockExtensionApi();
-      subagentDoneExtension(api);
-      assert.equal(registeredTools.some((tool) => tool.name === "set_tab_title"), true);
-    } finally {
-      restoreEnvVar("PI_DENY_TOOLS", previousDeniedTools);
-    }
-  });
-
-  it("skips set_tab_title in subagent sessions when denied", () => {
-    const previousDeniedTools = process.env.PI_DENY_TOOLS;
-
-    try {
-      process.env.PI_DENY_TOOLS = "set_tab_title,subagent";
-      const { api, registeredTools } = createMockExtensionApi();
-      subagentDoneExtension(api);
-      assert.equal(registeredTools.some((tool) => tool.name === "set_tab_title"), false);
-    } finally {
-      restoreEnvVar("PI_DENY_TOOLS", previousDeniedTools);
-    }
-  });
-
   it("expands spawning false to deny subagent interruption", () => {
     const testApi = (subagentsModule as any).__test__;
     const denied = testApi.resolveDenyTools({ spawning: false });

--- a/test/test.ts
+++ b/test/test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, readFileSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
 import { visibleWidth } from "@mariozechner/pi-tui";
 import * as subagentsModule from "../pi-extension/subagents/index.ts";
 
@@ -19,6 +20,21 @@ import {
 
 import { shellEscape, isCmuxAvailable, isWezTermAvailable } from "../pi-extension/subagents/cmux.ts";
 import {
+  advanceStatusState,
+  capStatusLines,
+  classifyStatus,
+  createStatusState,
+  forceStatusQuiet,
+  formatStatusAggregate,
+  getStalledAfterMs,
+  formatStatusLine,
+  formatTransitionLine,
+  observeStatus,
+  loadStatusConfig,
+  parseStatusConfig,
+  resolveStatusCadenceMs,
+} from "../pi-extension/subagents/status.ts";
+import subagentDoneExtension, {
   shouldMarkUserTookOver,
   shouldAutoExitOnAgentEnd,
 } from "../pi-extension/subagents/subagent-done.ts";
@@ -36,12 +52,27 @@ function createSessionFile(dir: string, entries: object[]): string {
   return file;
 }
 
+function withTempDir(run: (dir: string) => void) {
+  const dir = createTestDir();
+  try {
+    run(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 function createMockExtensionApi() {
   const registeredTools: Array<any> = [];
   const registeredCommands: Array<any> = [];
+  const registeredMessageRenderers: Array<any> = [];
+  const sentUserMessages: string[] = [];
+  const sentMessages: Array<any> = [];
   return {
     registeredTools,
     registeredCommands,
+    registeredMessageRenderers,
+    sentUserMessages,
+    sentMessages,
     api: {
       on() {},
       registerTool(tool: any) {
@@ -50,8 +81,16 @@ function createMockExtensionApi() {
       registerCommand(name: string, command: any) {
         registeredCommands.push({ name, ...command });
       },
-      registerMessageRenderer() {},
+      registerMessageRenderer(name: string, renderer: any) {
+        registeredMessageRenderers.push({ name, renderer });
+      },
       registerShortcut() {},
+      sendUserMessage(message: string) {
+        sentUserMessages.push(message);
+      },
+      sendMessage(message: any, options?: any) {
+        sentMessages.push({ message, options });
+      },
       getAllTools() {
         return [];
       },
@@ -65,6 +104,16 @@ function restoreEnvVar(name: string, value: string | undefined) {
     return;
   }
   process.env[name] = value;
+}
+
+function withMockedNow<T>(now: number, fn: () => T): T {
+  const originalNow = Date.now;
+  Date.now = () => now;
+  try {
+    return fn();
+  } finally {
+    Date.now = originalNow;
+  }
 }
 
 function writeAgentFile(
@@ -106,7 +155,6 @@ async function withIsolatedAgentEnv(
     rmSync(root, { recursive: true, force: true });
   }
 }
-
 const SESSION_HEADER = { type: "session", id: "sess-001", version: 3 };
 const MODEL_CHANGE = { type: "model_change", id: "mc-001", parentId: null };
 const USER_MSG = {
@@ -298,6 +346,52 @@ describe("session.ts", () => {
     });
   });
 
+  describe("seedSubagentSessionFile", () => {
+    it("creates a lineage-only child session with parent linkage and no copied turns", () => {
+      const parentFile = createSessionFile(dir, [SESSION_HEADER, MODEL_CHANGE, USER_MSG, ASSISTANT_MSG]);
+      const childFile = join(dir, "lineage-child.jsonl");
+
+      seedSubagentSessionFile({
+        mode: "lineage-only",
+        parentSessionFile: parentFile,
+        childSessionFile: childFile,
+        childCwd: "/tmp/child-cwd",
+      });
+
+      const lines = readFileSync(childFile, "utf8").trim().split("\n");
+      assert.equal(lines.length, 1);
+
+      const header = JSON.parse(lines[0]);
+      assert.equal(header.type, "session");
+      assert.equal(header.parentSession, parentFile);
+      assert.equal(header.cwd, "/tmp/child-cwd");
+    });
+
+    it("creates a forked child session with copied context before the triggering user turn", () => {
+      const parentFile = createSessionFile(dir, [SESSION_HEADER, MODEL_CHANGE, USER_MSG, ASSISTANT_MSG]);
+      const childFile = join(dir, "fork-child.jsonl");
+
+      seedSubagentSessionFile({
+        mode: "fork",
+        parentSessionFile: parentFile,
+        childSessionFile: childFile,
+        childCwd: "/tmp/fork-child-cwd",
+      });
+
+      const entries = readFileSync(childFile, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      assert.equal(entries.length, 2);
+      assert.equal(entries[0].type, "session");
+      assert.equal(entries[0].parentSession, parentFile);
+      assert.equal(entries[0].cwd, "/tmp/fork-child-cwd");
+      assert.equal(entries[1].type, "model_change");
+      assert.equal(entries.some((entry) => entry.type === "session" && entry.parentSession !== parentFile), false);
+      assert.equal(entries.some((entry) => entry.type === "message"), false);
+    });
+  });
+
   describe("mergeNewEntries", () => {
     it("appends new entries from source to target", () => {
       // Source starts with same base (2 entries), then has 1 new entry
@@ -324,56 +418,285 @@ describe("session.ts", () => {
   });
 });
 
-describe("seedSubagentSessionFile", () => {
-  let dir: string;
-  before(() => {
-    dir = createTestDir();
-  });
-  after(() => {
-    rmSync(dir, { recursive: true, force: true });
-  });
-
-  it("creates a lineage-only child session with parent linkage and no copied turns", () => {
-    const parentFile = createSessionFile(dir, [SESSION_HEADER, MODEL_CHANGE, USER_MSG, ASSISTANT_MSG]);
-    const childFile = join(dir, "lineage-child.jsonl");
-
-    seedSubagentSessionFile({
-      mode: "lineage-only",
-      parentSessionFile: parentFile,
-      childSessionFile: childFile,
-      childCwd: "/tmp/child-cwd",
+describe("status.ts", () => {
+  it("parses strict config objects and clamps cadence bounds", () => {
+    const disabled = parseStatusConfig({
+      status: {
+        enabled: false,
+        defaultCadenceSeconds: 5,
+      },
     });
 
-    const lines = readFileSync(childFile, "utf8").trim().split("\n");
-    assert.equal(lines.length, 1);
-
-    const header = JSON.parse(lines[0]);
-    assert.equal(header.type, "session");
-    assert.equal(header.parentSession, parentFile);
-    assert.equal(header.cwd, "/tmp/child-cwd");
+    assert.equal(disabled.enabled, false);
+    assert.equal(disabled.defaultCadenceMs, 10_000);
+    assert.equal(resolveStatusCadenceMs(disabled, 10), 10_000);
   });
 
-  it("creates a forked child session with copied context before the triggering user turn", () => {
-    const parentFile = createSessionFile(dir, [SESSION_HEADER, MODEL_CHANGE, USER_MSG, ASSISTANT_MSG]);
-    const childFile = join(dir, "fork-child.jsonl");
+  it("loads a valid config file", () => {
+    const examplePath = fileURLToPath(new URL("../config.json.example", import.meta.url));
+    const config = loadStatusConfig(examplePath);
 
-    seedSubagentSessionFile({
-      mode: "fork",
-      parentSessionFile: parentFile,
-      childSessionFile: childFile,
-      childCwd: "/tmp/fork-child-cwd",
+    assert.deepEqual(config, {
+      enabled: true,
+      defaultCadenceMs: 60_000,
+      lineLimit: 4,
+    });
+  });
+
+  it("loads the shared example when local config is absent", () => {
+    withTempDir((dir) => {
+      const examplePath = join(dir, "config.json.example");
+      writeFileSync(
+        examplePath,
+        JSON.stringify({ status: { enabled: true, defaultCadenceSeconds: 45 } }, null, 2) + "\n",
+      );
+
+      const config = loadStatusConfig(join(dir, "config.json"), examplePath);
+
+      assert.deepEqual(config, {
+        enabled: true,
+        defaultCadenceMs: 45_000,
+        lineLimit: 4,
+      });
+    });
+  });
+
+  it("fails fast for invalid config shapes", () => {
+    assert.throws(
+      () => parseStatusConfig({ status: { enabled: "false", defaultCadenceSeconds: 60 } }),
+      /status\.enabled must be a boolean/,
+    );
+    assert.throws(
+      () => parseStatusConfig({ status: { enabled: true } }),
+      /status\.defaultCadenceSeconds must be a positive integer/,
+    );
+  });
+
+  it("reports when neither local nor shared config exists", () => {
+    withTempDir((dir) => {
+      assert.throws(
+        () => loadStatusConfig(join(dir, "config.json"), join(dir, "config.json.example")),
+        /Missing subagent status config\. Expected .*config\.json.*or.*config\.json\.example/,
+      );
+    });
+  });
+
+  it("reports invalid JSON from the shared example path", () => {
+    withTempDir((dir) => {
+      const examplePath = join(dir, "config.json.example");
+      writeFileSync(examplePath, "{\n");
+
+      assert.throws(
+        () => loadStatusConfig(join(dir, "config.json"), examplePath),
+        /Invalid JSON in subagent config .*config\.json\.example/,
+      );
+    });
+  });
+
+  it("fails on invalid local config instead of falling back to the shared example", () => {
+    withTempDir((dir) => {
+      const configPath = join(dir, "config.json");
+      const examplePath = join(dir, "config.json.example");
+      writeFileSync(configPath, "{\n");
+      writeFileSync(
+        examplePath,
+        JSON.stringify({ status: { enabled: true, defaultCadenceSeconds: 45 } }, null, 2) + "\n",
+      );
+
+      assert.throws(
+        () => loadStatusConfig(configPath, examplePath),
+        /Invalid JSON in subagent config .*config\.json/,
+      );
+    });
+  });
+
+  it("keeps no-observation runs as starting, then marks them stalled", () => {
+    const state = createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 });
+
+    assert.equal(classifyStatus(state, 10_000).kind, "starting");
+    assert.equal(classifyStatus(state, 95_000).kind, "stalled");
+    assert.equal(classifyStatus(state, 95_000).idleText, "1m");
+  });
+
+  it("does not treat inherited baseline entries as fresh progress", () => {
+    let state = createStatusState({
+      source: "pi",
+      startTimeMs: 0,
+      cadenceMs: 60_000,
+      baselineEntries: 3,
+      baselineBytes: 300,
     });
 
-    const entries = readFileSync(childFile, "utf8")
-      .trim()
-      .split("\n")
-      .map((line) => JSON.parse(line));
-    assert.equal(entries.length, 2);
-    assert.equal(entries[0].type, "session");
-    assert.equal(entries[0].parentSession, parentFile);
-    assert.equal(entries[0].cwd, "/tmp/fork-child-cwd");
-    assert.equal(entries[1].type, "model_change");
-    assert.equal(entries.some((entry) => entry.type === "message"), false);
+    state = observeStatus(state, { entries: 3, bytes: 300 }, 1_000);
+    const snapshot = classifyStatus(state, 30_000);
+
+    assert.equal(snapshot.kind, "quiet");
+    assert.equal(snapshot.progressEvents, 0);
+  });
+
+  it("classifies active then quiet then stalled based on elapsed inactivity", () => {
+    let state = createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 });
+    state = observeStatus(state, { entries: 1, bytes: 100 }, 5_000);
+
+    assert.equal(classifyStatus(state, 10_000).kind, "active");
+    assert.equal(classifyStatus(state, 40_000).kind, "quiet");
+    assert.equal(classifyStatus(state, 95_000).kind, "stalled");
+  });
+
+  it("uses elapsed-only fallback for claude-backed subagents", () => {
+    const state = createStatusState({ source: "claude", startTimeMs: 0, cadenceMs: 30_000 });
+    const snapshot = classifyStatus(state, 125_000);
+
+    assert.equal(snapshot.kind, "running");
+    assert.equal(snapshot.elapsedText, "2m");
+  });
+
+  it("detects stalled transitions and recovery", () => {
+    let state = createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 });
+    state = observeStatus(state, { entries: 1, bytes: 100 }, 5_000);
+
+    let advanced = advanceStatusState(state, 95_000);
+    assert.equal(advanced.transition, "stalled");
+    assert.equal(advanced.snapshot.kind, "stalled");
+
+    state = observeStatus(advanced.nextState, { entries: 2, bytes: 200 }, 96_000);
+    advanced = advanceStatusState(state, 97_000);
+    assert.equal(advanced.transition, "recovered");
+    assert.equal(advanced.snapshot.kind, "active");
+  });
+
+  it("forces an active state to quiet without discarding observed progress", () => {
+    const now = 20_000;
+    let state = createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 });
+    state = observeStatus(state, { entries: 2, bytes: 200 }, 5_000);
+
+    assert.equal(classifyStatus(state, now).kind, "active");
+
+    const forced = forceStatusQuiet(state, now);
+    const snapshot = classifyStatus(forced, now);
+
+    assert.equal(snapshot.kind, "quiet");
+    assert.equal(forced.observedEntries, state.observedEntries);
+    assert.equal(forced.observedBytes, state.observedBytes);
+    assert.ok(snapshot.idleMs != null);
+    assert.ok(snapshot.idleMs >= forced.cadenceMs);
+    assert.ok(snapshot.idleMs < getStalledAfterMs(forced.cadenceMs));
+  });
+
+  it("forces a no-observation state to quiet for local bookkeeping", () => {
+    const now = 20_000;
+    const state = createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 });
+
+    const forced = forceStatusQuiet(state, now);
+
+    assert.equal(classifyStatus(forced, now).kind, "quiet");
+    assert.equal(forced.observedEntries, null);
+    assert.equal(forced.observedBytes, null);
+  });
+
+  it("lets a forced-quiet state become stalled under the existing timeout", () => {
+    const now = 20_000;
+    let state = createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 });
+    state = observeStatus(state, { entries: 2, bytes: 200 }, 5_000);
+
+    const forced = forceStatusQuiet(state, now);
+    const forcedSnapshot = classifyStatus(forced, now);
+    const stalledAt = now + (getStalledAfterMs(forced.cadenceMs) - (forcedSnapshot.idleMs as number));
+
+    assert.equal(classifyStatus(forced, stalledAt - 1).kind, "quiet");
+    assert.equal(classifyStatus(forced, stalledAt).kind, "stalled");
+  });
+
+  it("forces an already stalled state back to quiet until the timeout elapses again", () => {
+    const now = 95_000;
+    let state = createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 });
+    state = observeStatus(state, { entries: 2, bytes: 200 }, 5_000);
+
+    assert.equal(classifyStatus(state, now).kind, "stalled");
+
+    const forced = forceStatusQuiet(state, now);
+    const forcedSnapshot = classifyStatus(forced, now);
+    const stalledAgainAt = now + (getStalledAfterMs(forced.cadenceMs) - (forcedSnapshot.idleMs as number));
+
+    assert.equal(forcedSnapshot.kind, "quiet");
+    assert.equal(classifyStatus(forced, stalledAgainAt - 1).kind, "quiet");
+    assert.equal(classifyStatus(forced, stalledAgainAt).kind, "stalled");
+  });
+
+  it("returns to active when genuine new progress arrives after quiet is forced", () => {
+    const forcedAt = 20_000;
+    let state = createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 });
+    state = observeStatus(state, { entries: 2, bytes: 200 }, 5_000);
+    state = forceStatusQuiet(state, forcedAt);
+
+    const resumed = observeStatus(state, { entries: 3, bytes: 300 }, 25_000);
+
+    assert.equal(classifyStatus(resumed, 25_000).kind, "active");
+    assert.equal(resumed.observedEntries, 3);
+    assert.equal(resumed.observedBytes, 300);
+  });
+
+  it("normalizes and truncates long newline-heavy names", () => {
+    const longName = `Worker\n\n${"very-long-name-".repeat(12)}`;
+    const line = formatStatusLine(longName, {
+      kind: "stalled",
+      elapsedMs: 240_000,
+      elapsedText: "4m",
+      idleMs: 240_000,
+      idleText: "4m",
+      progressEvents: 0,
+    });
+    const recovered = formatTransitionLine(
+      longName,
+      {
+        kind: "active",
+        elapsedMs: 300_000,
+        elapsedText: "5m",
+        idleMs: 1_000,
+        idleText: "1s",
+        progressEvents: 2,
+      },
+      "recovered",
+    );
+
+    assert.doesNotMatch(line, /\n/);
+    assert.doesNotMatch(recovered, /\n/);
+    assert.ok(line.length <= 120, `expected bounded line length, got ${line.length}`);
+    assert.ok(recovered.length <= 120, `expected bounded line length, got ${recovered.length}`);
+  });
+
+  it("caps visible status lines and reports overflow consistently", () => {
+    const quietLine = formatStatusLine("Worker", {
+      kind: "quiet",
+      elapsedMs: 300_000,
+      elapsedText: "5m",
+      idleMs: 120_000,
+      idleText: "2m",
+      progressEvents: 0,
+    });
+    const recoveredLine = formatTransitionLine(
+      "Worker",
+      {
+        kind: "active",
+        elapsedMs: 420_000,
+        elapsedText: "7m",
+        idleMs: 1_000,
+        idleText: "1s",
+        progressEvents: 3,
+      },
+      "recovered",
+    );
+    const lines = [quietLine, recoveredLine, "Scout running 2m.", "Reviewer running 4m.", "Planner running 6m."];
+    const capped = capStatusLines(lines, 3);
+    const aggregate = formatStatusAggregate(lines, 3);
+
+    assert.equal(quietLine, "Worker running 5m, quiet 2m.");
+    assert.equal(recoveredLine, "Worker running 7m, recovered; active (+3 events).");
+    assert.deepEqual(capped.visibleLines, [quietLine, recoveredLine, "Scout running 2m."]);
+    assert.equal(capped.overflow, 2);
+    assert.match(aggregate, /^Subagent status:/);
+    assert.match(aggregate, /\+2 more running\./);
+    assert.doesNotMatch(aggregate, /\/tmp|\.jsonl/);
   });
 });
 
@@ -506,7 +829,7 @@ describe("subagent discovery", () => {
       const { api, registeredTools } = createMockExtensionApi();
       (subagentsModule as any).default(api);
 
-      const tool = registeredTools.find((t) => t.name === "subagents_list");
+      const tool = registeredTools.find((tool) => tool.name === "subagents_list");
       assert.ok(tool, "expected subagents_list to be registered");
 
       const result = await tool.execute();
@@ -534,7 +857,7 @@ describe("subagent discovery", () => {
       const { api, registeredTools } = createMockExtensionApi();
       (subagentsModule as any).default(api);
 
-      const tool = registeredTools.find((t) => t.name === "subagents_list");
+      const tool = registeredTools.find((tool) => tool.name === "subagents_list");
       assert.ok(tool, "expected subagents_list to be registered");
 
       const result = await tool.execute();
@@ -578,7 +901,7 @@ describe("subagent discovery", () => {
       const { api, registeredTools } = createMockExtensionApi();
       (subagentsModule as any).default(api);
 
-      const tool = registeredTools.find((t) => t.name === "subagents_list");
+      const tool = registeredTools.find((tool) => tool.name === "subagents_list");
       assert.ok(tool, "expected subagents_list to be registered");
 
       const result = await tool.execute();
@@ -595,7 +918,6 @@ describe("subagent discovery", () => {
     });
   });
 });
-
 describe("subagent-done.ts", () => {
   describe("shouldMarkUserTookOver", () => {
     it("ignores the initial injected task before the first agent run", () => {
@@ -624,6 +946,363 @@ describe("subagent-done.ts", () => {
     });
   });
 });
+describe("commands", () => {
+  it("/iterate always emits a full-context fork tool call", () => {
+    const { api, registeredCommands, sentUserMessages } = createMockExtensionApi();
+
+    (subagentsModule as any).default(api);
+
+    const iterate = registeredCommands.find((command) => command.name === "iterate");
+    assert.ok(iterate, "expected /iterate to be registered");
+
+    iterate.handler("Fix the bug", {});
+
+    assert.equal(sentUserMessages.length, 1);
+    assert.match(sentUserMessages[0], /fork: true/);
+    assert.match(sentUserMessages[0], /name: "Iterate"/);
+  });
+});
+
+describe("tool registration", () => {
+  it("does not register set_tab_title in the main session extension", () => {
+    const { api, registeredTools } = createMockExtensionApi();
+
+    (subagentsModule as any).default(api);
+
+    assert.equal(registeredTools.some((tool) => tool.name === "set_tab_title"), false);
+  });
+
+  it("registers set_tab_title in subagent sessions", () => {
+    const previousDeniedTools = process.env.PI_DENY_TOOLS;
+
+    try {
+      delete process.env.PI_DENY_TOOLS;
+      const { api, registeredTools } = createMockExtensionApi();
+      subagentDoneExtension(api);
+      assert.equal(registeredTools.some((tool) => tool.name === "set_tab_title"), true);
+    } finally {
+      restoreEnvVar("PI_DENY_TOOLS", previousDeniedTools);
+    }
+  });
+
+  it("skips set_tab_title in subagent sessions when denied", () => {
+    const previousDeniedTools = process.env.PI_DENY_TOOLS;
+
+    try {
+      process.env.PI_DENY_TOOLS = "set_tab_title,subagent";
+      const { api, registeredTools } = createMockExtensionApi();
+      subagentDoneExtension(api);
+      assert.equal(registeredTools.some((tool) => tool.name === "set_tab_title"), false);
+    } finally {
+      restoreEnvVar("PI_DENY_TOOLS", previousDeniedTools);
+    }
+  });
+
+  it("expands spawning false to deny subagent interruption", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const denied = testApi.resolveDenyTools({ spawning: false });
+
+    assert.equal(denied.has("subagent"), true);
+    assert.equal(denied.has("subagent_interrupt"), true);
+    assert.equal(denied.has("subagent_resume"), true);
+  });
+});
+
+describe("session progress observation", () => {
+  it("ignores only transient session-file races", () => {
+    const testApi = (subagentsModule as any).__test__;
+
+    assert.equal(testApi.isIgnorableSessionProgressError({ code: "ENOENT" }), true);
+    assert.equal(testApi.isIgnorableSessionProgressError({ code: "EBUSY" }), true);
+    assert.equal(testApi.isIgnorableSessionProgressError({ code: "EACCES" }), false);
+    assert.equal(testApi.isIgnorableSessionProgressError(new Error("boom")), false);
+  });
+});
+
+describe("subagent interruption", () => {
+  function makeRunning(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "a1",
+      name: "Worker",
+      task: "",
+      surface: "pane-1",
+      startTime: 0,
+      sessionFile: "worker.jsonl",
+      statusState: createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 }),
+      ...overrides,
+    };
+  }
+
+  it("registers subagent_interrupt in the main session extension", () => {
+    const { api, registeredTools } = createMockExtensionApi();
+
+    (subagentsModule as any).default(api);
+
+    assert.equal(registeredTools.some((tool) => tool.name === "subagent_interrupt"), true);
+  });
+
+  it("resolves interrupt targets by exact id and reports name ambiguity", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const runningMap = testApi.runningSubagents as Map<string, any>;
+    runningMap.clear();
+
+    try {
+      runningMap.set("a1", makeRunning({ id: "a1", name: "Worker", surface: "a1", sessionFile: "a1.jsonl" }));
+      runningMap.set("b2", makeRunning({ id: "b2", name: "Worker", surface: "b2", sessionFile: "b2.jsonl" }));
+      runningMap.set("c3", makeRunning({ id: "c3", name: "Scout", surface: "c3", sessionFile: "c3.jsonl" }));
+
+      const byId = testApi.resolveInterruptTarget({ id: "c3", name: "Worker" });
+      assert.equal(byId.running.id, "c3");
+
+      const ambiguous = testApi.resolveInterruptTarget({ name: "Worker" });
+      assert.match(ambiguous.error, /Ambiguous subagent name/);
+    } finally {
+      runningMap.clear();
+    }
+  });
+
+  it("returns an explicit error when Escape delivery fails", () => {
+    const testApi = (subagentsModule as any).__test__;
+    let aborted = false;
+    const running = makeRunning({
+      abortController: {
+        abort() {
+          aborted = true;
+        },
+      },
+    });
+
+    const result = testApi.requestSubagentInterrupt(running, () => {
+      throw new Error("mux write failed");
+    });
+
+    assert.match(result.error, /Failed to send Escape/);
+    assert.equal(aborted, false);
+    assert.equal("interruptRequested" in running, false);
+  });
+
+  it("leaves status unchanged when Escape delivery fails in the tool path", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const runningMap = testApi.runningSubagents as Map<string, any>;
+    runningMap.clear();
+
+    const activeState = observeStatus(
+      createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 }),
+      { entries: 1, bytes: 100 },
+      5_000,
+    );
+
+    try {
+      runningMap.set("a1", makeRunning({ statusState: activeState }));
+
+      const result = withMockedNow(20_000, () => testApi.handleSubagentInterrupt({ name: "Worker" }, () => {
+        throw new Error("mux write failed");
+      }));
+
+      assert.match(result.content[0].text, /Failed to send Escape/);
+      assert.equal(classifyStatus(runningMap.get("a1").statusState, 20_000).kind, "active");
+    } finally {
+      runningMap.clear();
+    }
+  });
+
+  it("sends Escape without aborting or mutating running state", () => {
+    const testApi = (subagentsModule as any).__test__;
+    let aborted = false;
+    let sentSurface = "";
+    const running = makeRunning({
+      abortController: {
+        abort() {
+          aborted = true;
+        },
+      },
+    });
+
+    const result = testApi.requestSubagentInterrupt(running, (surface: string) => {
+      sentSurface = surface;
+    });
+
+    assert.deepEqual(result, { ok: true });
+    assert.equal(sentSurface, "pane-1");
+    assert.equal(aborted, false);
+    assert.equal("interruptRequested" in running, false);
+  });
+
+  it("acknowledges Pi-backed interrupt requests and forces local status quiet", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const runningMap = testApi.runningSubagents as Map<string, any>;
+    let sentSurface = "";
+    runningMap.clear();
+
+    const activeState = observeStatus(
+      createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 }),
+      { entries: 1, bytes: 100 },
+      5_000,
+    );
+
+    try {
+      runningMap.set("a1", makeRunning({
+        sessionFile: "/tmp/does-not-exist.jsonl",
+        statusState: activeState,
+      }));
+
+      const result = withMockedNow(20_000, () => testApi.handleSubagentInterrupt({ name: "Worker" }, (surface: string) => {
+        sentSurface = surface;
+      }));
+
+      assert.equal(sentSurface, "pane-1");
+      assert.equal(result.content[0].text, 'Interrupt requested for subagent "Worker".');
+      assert.deepEqual(result.details, { id: "a1", name: "Worker", status: "interrupt_requested" });
+      assert.equal(classifyStatus(runningMap.get("a1").statusState, 20_000).kind, "quiet");
+      assert.equal(runningMap.has("a1"), true);
+    } finally {
+      runningMap.clear();
+    }
+  });
+
+  it("sends Escape again for repeated interrupt requests", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const runningMap = testApi.runningSubagents as Map<string, any>;
+    const surfaces: string[] = [];
+    runningMap.clear();
+
+    try {
+      runningMap.set("a1", makeRunning());
+
+      testApi.handleSubagentInterrupt({ name: "Worker" }, (surface: string) => {
+        surfaces.push(surface);
+      });
+      testApi.handleSubagentInterrupt({ name: "Worker" }, (surface: string) => {
+        surfaces.push(surface);
+      });
+
+      assert.deepEqual(surfaces, ["pane-1", "pane-1"]);
+      assert.equal(runningMap.has("a1"), true);
+    } finally {
+      runningMap.clear();
+    }
+  });
+
+  it("rejects Claude-backed interrupt requests before delivery", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const runningMap = testApi.runningSubagents as Map<string, any>;
+    let delivered = false;
+    runningMap.clear();
+
+    try {
+      runningMap.set("a1", makeRunning({ cli: "claude" }));
+
+      const result = testApi.handleSubagentInterrupt({ name: "Worker" }, () => {
+        delivered = true;
+      });
+
+      assert.equal(delivered, false);
+      assert.match(result.content[0].text, /currently supported only for Pi-backed subagents/i);
+      assert.deepEqual(result.details, {
+        error: "claude interrupt unsupported",
+        id: "a1",
+        name: "Worker",
+      });
+    } finally {
+      runningMap.clear();
+    }
+  });
+
+  it("formats exit code 130 as an ordinary failure", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const presentation = testApi.resolveResultPresentation(
+      {
+        exitCode: 130,
+        elapsed: 61,
+        summary: "Sub-agent exited with code 130",
+        sessionFile: "/tmp/subagent.jsonl",
+      },
+      "Worker",
+    );
+
+    assert.match(presentation, /failed \(exit code 130\)/);
+    assert.doesNotMatch(presentation, /interrupted/);
+    assert.match(presentation, /Resume: pi --session/);
+  });
+});
+
+describe("subagent status renderer", () => {
+  function createTheme() {
+    return {
+      fg(_color: string, text: string) {
+        return text;
+      },
+      bg(_color: string, text: string) {
+        return text;
+      },
+      bold(text: string) {
+        return text;
+      },
+    };
+  }
+
+  it("renders only capped lines plus overflow", () => {
+    const { api, registeredMessageRenderers } = createMockExtensionApi();
+    (subagentsModule as any).default(api);
+
+    const rendererEntry = registeredMessageRenderers.find((entry) => entry.name === "subagent_status");
+    assert.ok(rendererEntry, "expected subagent_status renderer to be registered");
+
+    const visibleLines = [
+      "Worker running 5m, stalled 5m.",
+      "Scout running 3m, stalled 3m.",
+      "Reviewer running 2m, stalled 2m.",
+      "Planner running 4m, stalled 4m.",
+    ];
+    const rendered = rendererEntry.renderer(
+      {
+        customType: "subagent_status",
+        content: "Subagent status:\n• Worker running 5m, stalled 5m.",
+        details: {
+          lines: visibleLines,
+          overflow: 2,
+        },
+      },
+      { expanded: true },
+      createTheme(),
+    );
+    const output = rendered.render(80).join("\n");
+
+    assert.match(output, /Subagent status/);
+    for (const line of visibleLines) {
+      assert.match(output, new RegExp(line.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    }
+    assert.match(output, /\+2 more running\./);
+  });
+
+  it("stays within narrow widths", () => {
+    const { api, registeredMessageRenderers } = createMockExtensionApi();
+    (subagentsModule as any).default(api);
+
+    const rendererEntry = registeredMessageRenderers.find((entry) => entry.name === "subagent_status");
+    assert.ok(rendererEntry, "expected subagent_status renderer to be registered");
+
+    const rendered = rendererEntry.renderer(
+      {
+        customType: "subagent_status",
+        content: "Subagent status:\n• Worker running 5m, stalled 5m.",
+        details: { lines: ["Worker running 5m, stalled 5m."], overflow: 0 },
+      },
+      { expanded: true },
+      createTheme(),
+    );
+
+    for (const width of [4, 5, 6]) {
+      for (const line of rendered.render(width)) {
+        assert.ok(
+          visibleWidth(line) <= width,
+          `expected line width <= ${width}, got ${visibleWidth(line)} for ${JSON.stringify(line)}`,
+        );
+      }
+    }
+  });
+});
+
 describe("subagent startup delay", () => {
   it("defaults to 500ms when no env var is set", () => {
     const testApi = (subagentsModule as any).__test__;
@@ -655,7 +1334,6 @@ describe("subagent startup delay", () => {
     }
   });
 });
-
 describe("subagents widget rendering", () => {
   it("keeps every rendered line within a very narrow width", () => {
     const testApi = (subagentsModule as any).__test__;
@@ -675,6 +1353,7 @@ describe("subagents widget rendering", () => {
           sessionFile: "sess1",
           entries: 13,
           bytes: 55.6 * 1024,
+          statusState: createStatusState({ source: "pi", startTimeMs: 1_000_000 - 13_000, cadenceMs: 30_000 }),
         },
         {
           id: "a2",
@@ -685,6 +1364,7 @@ describe("subagents widget rendering", () => {
           sessionFile: "sess2",
           entries: 21,
           bytes: 115.6 * 1024,
+          statusState: createStatusState({ source: "pi", startTimeMs: 1_000_000 - 21_000, cadenceMs: 30_000 }),
         },
         {
           id: "a3",
@@ -695,6 +1375,7 @@ describe("subagents widget rendering", () => {
           sessionFile: "sess3",
           entries: 27,
           bytes: 106.8 * 1024,
+          statusState: createStatusState({ source: "pi", startTimeMs: 1_000_000 - 27_000, cadenceMs: 30_000 }),
         },
       ], 16);
 
@@ -723,16 +1404,18 @@ describe("subagents widget rendering", () => {
 
     const widths = [0, 1, 2];
     for (const width of widths) {
+      const startTime = Date.now() - 5_000;
       const lines = testApi.renderSubagentWidgetLines([
         {
           id: "a1",
           name: "A",
           task: "",
           surface: "s1",
-          startTime: Date.now() - 5_000,
+          startTime,
           sessionFile: "sess1",
           entries: 1,
           bytes: 1,
+          statusState: createStatusState({ source: "pi", startTimeMs: startTime, cadenceMs: 30_000 }),
         },
       ], width);
 


### PR DESCRIPTION
1. Adds lightweight status supervision.  The widget tracks each subagent/child's progress and labels it `starting`, `active`, `quiet`, or `stalled` based on session-file activity.  Routine status (continually refreshed and tracking all state transitions) stays in the widget only; the parent model is steered only when a run enters `stalled` or recovers from `stalled`, keeping token cost low during typical workflows.  Status defaults are loaded from a repo-local `config.json` — this controls whether status supervision is enabled and the idle-time window used to classify runs as `active`, `quiet`, or `stalled`.
2. Also adds `subagent_interrupt`, a tool for orchestrating agents that sends Escape to cancel a Pi-backed child's active turn without killing the session.  The pane, session file, and background polling all stay alive after the interrupt.  The widget immediately shows the interrupted child as `quiet`, and later real progress can return it to `active`.

Summary of changes:
- status: add baseline-aware status tracking in `status.ts` with `starting`, `active`, `quiet`, `stalled`, and `running` states derived from session-file entry/byte growth
- widget: render live per-child status, cap status lines/aggregates, and surface only `stalled`/`recovered` transitions as compact `subagent_status` steer messages to the parent
- config: load status defaults from repo-root `config.json` with strict validation; commit shared defaults in `config.json.example` and gitignore local overrides
- defaults: lower the shared default idle-time window to 60 seconds so `quiet`/`stalled` classification happens sooner
- tools: add `statusCadenceSeconds` to `subagent` and `subagent_resume` for per-run idle-time window overrides
- interrupt: add `subagent_interrupt` as a turn-only Escape request with immediate acknowledgement; on success, force the widget to show `quiet` immediately
- interrupt safety: the interrupt does not abort watchers, close panes, remove running children, or emit a synthetic `subagent_result`
- policy: deny `subagent_interrupt` under `spawning: false` so subagent lifecycle control stays consistent
- tests: unit coverage for status classification, config loading, interrupt delivery, and forced-quiet behavior; integration coverage for stalled-status delivery and mux-level Escape
- docs: update the README with status visibility, config workflow, and interruption semantics

Testing:
- `npm test` - all pass
- `npm run test:integration` - all pass
- Manually verified e2e (beyond new integration tests):
  - Single interrupt keeps the child alive and flips the widget to `quiet` immediately
  - Repeated interrupts remain non-terminal
  - `stalled` → `recovered` transitions steer back correctly
  - repo-config default cadence applies without a per-run override
  - `subagent_resume` with `statusCadenceSeconds` participates in the same status model

Example screenshots:

<img width="390" height="73" alt="Screenshot 2026-04-22 at 3 44 48 AM" src="https://github.com/user-attachments/assets/7e7f9502-ec64-408c-a2cb-26a1a5471646" />
-
<img width="466" height="98" alt="Screenshot 2026-04-21 at 8 48 20 PM" src="https://github.com/user-attachments/assets/3242f953-190d-4b1e-980e-bf4ed6c1b698" />
-
<img width="441" height="237" alt="Screenshot 2026-04-22 at 3 19 01 AM" src="https://github.com/user-attachments/assets/f7dc9aaf-71e6-47bd-9d35-9bc030e2a00a" />
-
<img width="449" height="217" alt="Screenshot 2026-04-22 at 3 16 47 AM" src="https://github.com/user-attachments/assets/4baf0d24-984e-433f-bab4-29a58391ef6f" />
-
<img width="895" height="400" alt="Screenshot 2026-04-22 at 3 20 29 AM" src="https://github.com/user-attachments/assets/7559cb0d-4f60-4669-aa0f-c23d7310a714" />
-
<img width="685" height="312" alt="Screenshot 2026-04-22 at 12 43 55 AM" src="https://github.com/user-attachments/assets/fd8075ad-bc94-4720-9ecb-461cb16d3d63" />
