### PR TITLE
feat(subagents): add kitty as a supported terminal backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Supported multiplexers:
 - [tmux](https://github.com/tmux/tmux)
 - [zellij](https://zellij.dev)
 - [WezTerm](https://wezfurlong.org/wezterm/) (terminal emulator with built-in multiplexing)
+- [kitty](https://sw.kovidgoyal.net/kitty/) (terminal emulator with built-in remote control)
 
 Start pi inside one of them:
 
@@ -46,9 +47,11 @@ tmux new -A -s pi 'pi'
 zellij --session pi   # then run: pi
 # or
 # just run pi inside WezTerm — no wrapper needed
+# or
+# just run pi inside kitty — no wrapper needed (requires allow_remote_control yes in kitty.conf)
 ```
 
-Optional: set `PI_SUBAGENT_MUX=cmux|tmux|zellij|wezterm` to force a specific backend.
+Optional: set `PI_SUBAGENT_MUX=cmux|tmux|zellij|wezterm|kitty` to force a specific backend.
 
 If your shell startup is slow and subagent commands sometimes get dropped before the prompt is ready, set `PI_SUBAGENT_SHELL_READY_DELAY_MS` to a higher value (defaults to `500`):
 
@@ -385,6 +388,9 @@ Every sub-agent session displays a compact tools widget showing available and de
   - [tmux](https://github.com/tmux/tmux)
   - [zellij](https://zellij.dev)
   - [WezTerm](https://wezfurlong.org/wezterm/)
+  - [kitty](https://sw.kovidgoyal.net/kitty/) — requires `allow_remote_control yes` in `kitty.conf`
+
+> **Kitty tip:** For the most reliable experience (especially crash detection), also add `listen_on unix:/tmp/kitty-$UID.sock` to `kitty.conf`. This lets pi communicate with kitty via a socket instead of the terminal, avoiding any terminal interference.
 
 ```bash
 cmux pi
@@ -393,13 +399,13 @@ tmux new -A -s pi 'pi'
 # or
 zellij --session pi   # then run: pi
 # or
-# just run pi inside WezTerm
+# just run pi inside WezTerm or kitty — no wrapper needed
 ```
 
 Optional backend override:
 
 ```bash
-export PI_SUBAGENT_MUX=cmux   # or tmux, zellij, wezterm
+export PI_SUBAGENT_MUX=cmux   # or tmux, zellij, wezterm, kitty
 ```
 
 ## License

--- a/pi-extension/subagents/cmux.ts
+++ b/pi-extension/subagents/cmux.ts
@@ -6,7 +6,7 @@ import { basename, dirname, join } from "node:path";
 
 const execFileAsync = promisify(execFile);
 
-export type MuxBackend = "cmux" | "tmux" | "zellij" | "wezterm";
+export type MuxBackend = "cmux" | "tmux" | "zellij" | "wezterm" | "kitty";
 
 const commandAvailability = new Map<string, boolean>();
 
@@ -29,7 +29,7 @@ function hasCommand(command: string): boolean {
 
 function muxPreference(): MuxBackend | null {
   const pref = (process.env.PI_SUBAGENT_MUX ?? "").trim().toLowerCase();
-  if (pref === "cmux" || pref === "tmux" || pref === "zellij" || pref === "wezterm") return pref;
+  if (pref === "cmux" || pref === "tmux" || pref === "zellij" || pref === "wezterm" || pref === "kitty") return pref;
   return null;
 }
 
@@ -49,6 +49,10 @@ function isWezTermRuntimeAvailable(): boolean {
   return !!process.env.WEZTERM_UNIX_SOCKET && hasCommand("wezterm");
 }
 
+function isKittyRuntimeAvailable(): boolean {
+  return !!process.env.KITTY_WINDOW_ID && hasCommand("kitten");
+}
+
 export function isCmuxAvailable(): boolean {
   return isCmuxRuntimeAvailable();
 }
@@ -65,17 +69,23 @@ export function isWezTermAvailable(): boolean {
   return isWezTermRuntimeAvailable();
 }
 
+export function isKittyAvailable(): boolean {
+  return isKittyRuntimeAvailable();
+}
+
 export function getMuxBackend(): MuxBackend | null {
   const pref = muxPreference();
   if (pref === "cmux") return isCmuxRuntimeAvailable() ? "cmux" : null;
   if (pref === "tmux") return isTmuxRuntimeAvailable() ? "tmux" : null;
   if (pref === "zellij") return isZellijRuntimeAvailable() ? "zellij" : null;
   if (pref === "wezterm") return isWezTermRuntimeAvailable() ? "wezterm" : null;
+  if (pref === "kitty") return isKittyRuntimeAvailable() ? "kitty" : null;
 
   if (isCmuxRuntimeAvailable()) return "cmux";
   if (isTmuxRuntimeAvailable()) return "tmux";
   if (isZellijRuntimeAvailable()) return "zellij";
   if (isWezTermRuntimeAvailable()) return "wezterm";
+  if (isKittyRuntimeAvailable()) return "kitty";
   return null;
 }
 
@@ -97,7 +107,10 @@ export function muxSetupHint(): string {
   if (pref === "wezterm") {
     return "Start pi inside WezTerm.";
   }
-  return "Start pi inside cmux (`cmux pi`), tmux (`tmux new -A -s pi 'pi'`), zellij (`zellij --session pi`, then run `pi`), or WezTerm.";
+  if (pref === "kitty") {
+    return "Start pi inside kitty with remote control enabled (`allow_remote_control yes` in kitty.conf).";
+  }
+  return "Start pi inside cmux (`cmux pi`), tmux (`tmux new -A -s pi 'pi'`), zellij (`zellij --session pi`, then run `pi`), WezTerm, or kitty (with `allow_remote_control yes` in kitty.conf).";
 }
 
 function requireMuxBackend(): MuxBackend {
@@ -331,6 +344,30 @@ export function createSurfaceSplit(
     return paneId;
   }
 
+  if (backend === "kitty") {
+    // Creates a new tab in the current OS window, returns the kitty window ID.
+    // Direction and fromSurface are not applicable for tab creation.
+    const args = ["@", "launch", "--type=tab", "--tab-title", name, "--keep-focus", "--cwd", process.cwd()];
+    let windowId: string;
+    try {
+      windowId = execFileSync("kitten", args, { encoding: "utf8" }).trim();
+    } catch (err: any) {
+      const msg = String(err?.stderr || err?.message || err);
+      if (msg.includes("Remote control is disabled") || msg.includes("remote control")) {
+        throw new Error(
+          "Kitty remote control is disabled. " +
+          "Ensure `allow_remote_control yes` is in ~/.config/kitty/kitty.conf, " +
+          "then fully restart kitty (config reload is not sufficient for this setting)."
+        );
+      }
+      throw err;
+    }
+    if (!windowId || !/^\d+$/.test(windowId)) {
+      throw new Error(`Unexpected kitten launch output: ${windowId || "(empty)"}`);
+    }
+    return windowId;
+  }
+
   // zellij
   const directionArg = direction === "left" || direction === "right" ? "right" : "down";
   const args = ["new-pane", "--direction", directionArg, "--name", name, "--cwd", process.cwd()];
@@ -408,6 +445,12 @@ export function renameCurrentTab(title: string): void {
     return;
   }
 
+  if (backend === "kitty") {
+    // Rename the current tab (the one running this pi instance).
+    execFileSync("kitten", ["@", "set-tab-title", title], { encoding: "utf8" });
+    return;
+  }
+
   // zellij: rename the agent's own pane, not the whole tab. In multi-pane layouts,
   // rename-tab clobbers the user's tab title whenever a subagent starts or /plan runs.
   // Closes #21.
@@ -463,6 +506,11 @@ export function renameWorkspace(title: string): void {
     return;
   }
 
+  if (backend === "kitty") {
+    // Kitty has no session/workspace concept; tab rename is sufficient.
+    return;
+  }
+
   // Skip session rename for zellij. rename-session renames the socket file
   // but the ZELLIJ_SESSION_NAME env var in the parent process keeps the old
   // name, so all subsequent `zellij action ...` CLI calls fail with
@@ -493,6 +541,15 @@ export function sendCommand(surface: string, command: string): void {
 
   if (backend === "wezterm") {
     execFileSync("wezterm", ["cli", "send-text", "--pane-id", surface, "--no-paste", command + "\n"], {
+      encoding: "utf8",
+    });
+    return;
+  }
+
+  if (backend === "kitty") {
+    // surface is the kitty window ID (numeric string).
+    // send-text sends literal text; include a real newline to execute the command.
+    execFileSync("kitten", ["@", "send-text", "--match", `id:${surface}`, "--", command + "\n"], {
       encoding: "utf8",
     });
     return;
@@ -571,6 +628,15 @@ export function readScreen(surface: string, lines = 50): string {
     return tailLines(raw, lines);
   }
 
+  if (backend === "kitty") {
+    const raw = execFileSync(
+      "kitten",
+      ["@", "get-text", "--match", `id:${surface}`],
+      { encoding: "utf8" },
+    );
+    return tailLines(raw, lines);
+  }
+
   // Zellij 0.44+: use --pane-id flag + stdout instead of env var + temp file.
   // The ZELLIJ_PANE_ID env var doesn't reliably target other panes for dump-screen,
   // and --path may silently fail to create the file. Stdout capture is robust.
@@ -616,6 +682,15 @@ export async function readScreenAsync(surface: string, lines = 50): Promise<stri
     return tailLines(stdout, lines);
   }
 
+  if (backend === "kitty") {
+    const { stdout } = await execFileAsync(
+      "kitten",
+      ["@", "get-text", "--match", `id:${surface}`],
+      { encoding: "utf8" },
+    );
+    return tailLines(stdout, lines);
+  }
+
   // Zellij 0.44+: use --pane-id flag + stdout instead of env var + temp file.
   const paneId = zellijPaneId(surface);
   const { stdout } = await execFileAsync(
@@ -648,6 +723,18 @@ export function closeSurface(surface: string): void {
     execFileSync("wezterm", ["cli", "kill-pane", "--pane-id", surface], {
       encoding: "utf8",
     });
+    return;
+  }
+
+  if (backend === "kitty") {
+    // Close the window (and its containing tab if it was the only window).
+    try {
+      execFileSync("kitten", ["@", "close-window", "--match", `id:${surface}`, "--no-response"], {
+        encoding: "utf8",
+      });
+    } catch {
+      // Optional — the tab may have already been closed by the shell exiting.
+    }
     return;
   }
 

--- a/pi-extension/subagents/cmux.ts
+++ b/pi-extension/subagents/cmux.ts
@@ -629,9 +629,17 @@ export function readScreen(surface: string, lines = 50): string {
   }
 
   if (backend === "kitty") {
+    // kitten @ communicates via APC escape sequences through the terminal pty.
+    // When called from the parent pi process this races with pi's own stdin
+    // reader, causing the response bytes to corrupt pi's input buffer.
+    // Prefer the KITTY_LISTEN_ON socket (set when listen_on is configured in
+    // kitty.conf) which avoids the terminal entirely.  If the socket is not
+    // available, return empty so the caller falls back to file-based detection.
+    const listenOn = process.env.KITTY_LISTEN_ON;
+    if (!listenOn) return "";
     const raw = execFileSync(
       "kitten",
-      ["@", "get-text", "--match", `id:${surface}`],
+      ["@", "--to", listenOn, "get-text", "--match", `id:${surface}`],
       { encoding: "utf8" },
     );
     return tailLines(raw, lines);
@@ -683,9 +691,11 @@ export async function readScreenAsync(surface: string, lines = 50): Promise<stri
   }
 
   if (backend === "kitty") {
+    const listenOn = process.env.KITTY_LISTEN_ON;
+    if (!listenOn) return "";
     const { stdout } = await execFileAsync(
       "kitten",
-      ["@", "get-text", "--match", `id:${surface}`],
+      ["@", "--to", listenOn, "get-text", "--match", `id:${surface}`],
       { encoding: "utf8" },
     );
     return tailLines(stdout, lines);
@@ -791,7 +801,11 @@ export async function pollForExit(
     if (options.sentinelFile) {
       try {
         if (existsSync(options.sentinelFile)) {
-          return { reason: "sentinel", exitCode: 0 };
+          let exitCode = 0;
+          try {
+            exitCode = parseInt(readFileSync(options.sentinelFile, "utf8").trim(), 10) || 0;
+          } catch {}
+          return { reason: "sentinel", exitCode };
         }
       } catch {}
     }

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -1400,10 +1400,18 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         }
 
         // Build env prefix — propagate PI_CODING_AGENT_DIR for config isolation
+        // Also set PI_SUBAGENT_AUTO_EXIT and PI_SUBAGENT_SESSION so the resumed agent
+        // can self-terminate (auto-exit listener + subagent_done/.exit sidecar).
         const resumeEnvParts: string[] = [];
         if (process.env.PI_CODING_AGENT_DIR) {
           resumeEnvParts.push(`PI_CODING_AGENT_DIR=${shellEscape(process.env.PI_CODING_AGENT_DIR)}`);
         }
+        // Enable auto-exit so the resumed session shuts down after the agent finishes
+        resumeEnvParts.push(`PI_SUBAGENT_AUTO_EXIT=1`);
+        // Set session file path so subagent_done / caller_ping can write the .exit sidecar
+        resumeEnvParts.push(`PI_SUBAGENT_SESSION=${shellEscape(params.sessionPath)}`);
+        // Propagate name for widget display
+        resumeEnvParts.push(`PI_SUBAGENT_NAME=${shellEscape(name)}`);
         const resumeEnvPrefix = resumeEnvParts.length > 0 ? resumeEnvParts.join(" ") + " " : "";
 
         const command = `${resumeEnvPrefix}${parts.join(" ")}; echo '__SUBAGENT_DONE_'$?'__'`;

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -832,13 +832,18 @@ async function launchSubagent(
   const cdPrefix = effectiveCwd ? `cd ${shellEscape(effectiveCwd)} && ` : "";
 
   const piCommand = cdPrefix + envPrefix + parts.join(" ");
-  const command = `${piCommand}; echo '__SUBAGENT_DONE_'$?'__'`;
   const launchScriptName = `${(params.name || "subagent")
     .toLowerCase()
     .replace(/[^a-z0-9\s-]/g, "")
     .replace(/\s+/g, "-")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "") || "subagent"}-${id}.sh`;
+  // Write the exit code to a sentinel file so pollForExit can detect crashes
+  // via a plain file-existence check (no screen polling required). This is
+  // especially important for the kitty backend where kitten @ get-text
+  // communicates via APC sequences that can corrupt the parent's input.
+  const sentinelFile = join(artifactDir, "subagent-scripts", `${launchScriptName}.done`);
+  const command = `${piCommand}; _PI_EXIT=$?; echo $_PI_EXIT > ${shellEscape(sentinelFile)} 2>/dev/null; echo '__SUBAGENT_DONE_'$_PI_EXIT'__'`;
   const launchScriptFile = join(artifactDir, "subagent-scripts", launchScriptName);
   sendLongCommand(surface, command, {
     scriptPath: launchScriptFile,
@@ -859,6 +864,7 @@ async function launchSubagent(
     startTime,
     sessionFile: subagentSessionFile,
     launchScriptFile,
+    sentinelFile,
   };
 
   runningSubagents.set(id, running);

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -135,6 +135,14 @@ export default function (pi: ExtensionAPI) {
         return;
       }
 
+      // Write .exit sidecar so the parent detects exit via the fast file-check
+      // path in pollForExit, without needing to poll the terminal screen.
+      // This avoids the kitty APC-over-pty race that corrupts the parent's input.
+      const sessionFile = process.env.PI_SUBAGENT_SESSION;
+      if (sessionFile) {
+        try { writeFileSync(`${sessionFile}.exit`, JSON.stringify({ type: "done" })); } catch {}
+      }
+
       ctx.shutdown();
     });
   }


### PR DESCRIPTION
> Done with the help of an AI agent. Manually tested that it works with kitty. Didn't test other implementations.

> Each commit's body contains an explanation as to why that particular change was necessary.



Uses kitten @ remote control CLI to implement all surface operations.
Each subagent gets a new kitty tab (kitten @ launch --type=tab).
Surface identifier is the kitty window ID returned by launch.

Operations:
- createSurface: kitten @ launch --type=tab, returns numeric window ID
- sendCommand:   kitten @ send-text --match id:<id>
- readScreen:    kitten @ get-text  --match id:<id>
- closeSurface:  kitten @ close-window --match id:<id> --no-response
- renameTab:     kitten @ set-tab-title (no match = current tab)
- renameWorkspace: no-op (kitty has no session concept)

Detection: KITTY_WINDOW_ID env var + kitten command present.
Auto-detection order places kitty last so tmux-inside-kitty prefers tmux.
Force with PI_SUBAGENT_MUX=kitty.

Requires allow_remote_control yes in kitty.conf + full kitty restart.
Emits an actionable error when kitten reports remote control is disabled.




https://github.com/user-attachments/assets/51806b07-eb70-47d8-b641-c1fa6a96f998

