### PR TITLE
feat(mux): herdr multiplexer backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ pi install git:github.com/HazAT/pi-interactive-subagents
 
 Supported multiplexers:
 
+- [herdr](https://github.com/ogulcancelik/herdr) (terminal workspace manager for AI coding agents)
 - [cmux](https://github.com/manaflow-ai/cmux)
 - [tmux](https://github.com/tmux/tmux)
 - [zellij](https://zellij.dev)
@@ -39,6 +40,8 @@ Supported multiplexers:
 Start pi inside one of them:
 
 ```bash
+herdr            # then run: pi
+# or
 cmux pi
 # or
 tmux new -A -s pi 'pi'
@@ -48,7 +51,9 @@ zellij --session pi   # then run: pi
 # just run pi inside WezTerm — no wrapper needed
 ```
 
-Optional: set `PI_SUBAGENT_MUX=cmux|tmux|zellij|wezterm` to force a specific backend.
+When multiple multiplexers are available, **herdr takes precedence** (detected via `HERDR_ENV=1`), then cmux, tmux, zellij, WezTerm.
+
+Optional: set `PI_SUBAGENT_MUX=herdr|cmux|tmux|zellij|wezterm` to force a specific backend.
 
 If your shell startup is slow and subagent commands sometimes get dropped before the prompt is ready, set `PI_SUBAGENT_SHELL_READY_DELAY_MS` to a higher value (defaults to `500`):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-interactive-subagents",
-  "version": "1.6.0",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-interactive-subagents",
-      "version": "1.6.0",
+      "version": "3.4.0",
       "license": "MIT",
       "devDependencies": {
         "@mariozechner/pi-coding-agent": "^0.65.0",

--- a/pi-extension/subagents/cmux.ts
+++ b/pi-extension/subagents/cmux.ts
@@ -6,7 +6,7 @@ import { basename, dirname, join } from "node:path";
 
 const execFileAsync = promisify(execFile);
 
-export type MuxBackend = "cmux" | "tmux" | "zellij" | "wezterm";
+export type MuxBackend = "cmux" | "tmux" | "zellij" | "wezterm" | "herdr";
 
 const commandAvailability = new Map<string, boolean>();
 
@@ -29,7 +29,7 @@ function hasCommand(command: string): boolean {
 
 function muxPreference(): MuxBackend | null {
   const pref = (process.env.PI_SUBAGENT_MUX ?? "").trim().toLowerCase();
-  if (pref === "cmux" || pref === "tmux" || pref === "zellij" || pref === "wezterm") return pref;
+  if (pref === "cmux" || pref === "tmux" || pref === "zellij" || pref === "wezterm" || pref === "herdr") return pref;
   return null;
 }
 
@@ -49,6 +49,14 @@ function isWezTermRuntimeAvailable(): boolean {
   return !!process.env.WEZTERM_UNIX_SOCKET && hasCommand("wezterm");
 }
 
+function isHerdrRuntimeAvailable(): boolean {
+  if (process.env.HERDR_ENV !== "1") return false;
+  const socket = process.env.HERDR_SOCKET_PATH;
+  if (!socket) return false;
+  if (!existsSync(socket)) return false;
+  return hasCommand("herdr");
+}
+
 export function isCmuxAvailable(): boolean {
   return isCmuxRuntimeAvailable();
 }
@@ -65,13 +73,19 @@ export function isWezTermAvailable(): boolean {
   return isWezTermRuntimeAvailable();
 }
 
+export function isHerdrAvailable(): boolean {
+  return isHerdrRuntimeAvailable();
+}
+
 export function getMuxBackend(): MuxBackend | null {
   const pref = muxPreference();
   if (pref === "cmux") return isCmuxRuntimeAvailable() ? "cmux" : null;
   if (pref === "tmux") return isTmuxRuntimeAvailable() ? "tmux" : null;
   if (pref === "zellij") return isZellijRuntimeAvailable() ? "zellij" : null;
   if (pref === "wezterm") return isWezTermRuntimeAvailable() ? "wezterm" : null;
+  if (pref === "herdr") return isHerdrRuntimeAvailable() ? "herdr" : null;
 
+  if (isHerdrRuntimeAvailable()) return "herdr";
   if (isCmuxRuntimeAvailable()) return "cmux";
   if (isTmuxRuntimeAvailable()) return "tmux";
   if (isZellijRuntimeAvailable()) return "zellij";
@@ -97,7 +111,10 @@ export function muxSetupHint(): string {
   if (pref === "wezterm") {
     return "Start pi inside WezTerm.";
   }
-  return "Start pi inside cmux (`cmux pi`), tmux (`tmux new -A -s pi 'pi'`), zellij (`zellij --session pi`, then run `pi`), or WezTerm.";
+  if (pref === "herdr") {
+    return "Start pi inside a herdr pane.";
+  }
+  return "Start pi inside a herdr pane, cmux (`cmux pi`), tmux (`tmux new -A -s pi 'pi'`), zellij (`zellij --session pi`, then run `pi`), or WezTerm.";
 }
 
 function requireMuxBackend(): MuxBackend {
@@ -132,6 +149,77 @@ function tailLines(text: string, lines: number): string {
   const split = text.split("\n");
   if (split.length <= lines) return text;
   return split.slice(-lines).join("\n");
+}
+
+interface HerdrEnvelope {
+  id?: string;
+  type?: string;
+  result?: unknown;
+  error?: { code?: string; message?: string };
+}
+
+function parseHerdrEnvelope(raw: string, args: string[]): unknown {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    // Action commands (send-text, send-keys, pane close, tab rename) return
+    // empty stdout on success. Errors always come through as JSON, so empty
+    // means success.
+    return null;
+  }
+  let data: HerdrEnvelope;
+  try {
+    data = JSON.parse(trimmed) as HerdrEnvelope;
+  } catch {
+    // Some herdr commands may emit plain text (e.g. pane read). Return as-is
+    // so callers can decide how to handle it.
+    return trimmed;
+  }
+  if (data.error) {
+    const msg = data.error.message ?? "unknown error";
+    const code = data.error.code ? ` (${data.error.code})` : "";
+    throw new Error(`herdr ${args.join(" ")}: ${msg}${code}`);
+  }
+  return data.result;
+}
+
+function herdrRpc(args: string[]): unknown {
+  const raw = execFileSync("herdr", args, { encoding: "utf8" });
+  return parseHerdrEnvelope(raw, args);
+}
+
+async function herdrRpcAsync(args: string[]): Promise<unknown> {
+  const { stdout } = await execFileAsync("herdr", args, { encoding: "utf8" });
+  return parseHerdrEnvelope(stdout, args);
+}
+
+// Minimum tail size for herdr reads. pollForExit asks for 5 lines of recent
+// scrollback to scan for the exit sentinel, but starship-style multi-line
+// prompts can push the sentinel past line 5 in the steady state. 50 keeps
+// the sentinel in view across realistic prompt shapes.
+const HERDR_MIN_TAIL_LINES = 50;
+
+function extractHerdrPaneId(result: unknown, args: string[]): string {
+  const r = result as { pane?: { pane_id?: string } } | null;
+  const paneId = r?.pane?.pane_id;
+  if (typeof paneId !== "string" || !paneId) {
+    throw new Error(`herdr ${args.join(" ")}: could not extract pane_id from ${JSON.stringify(result)}`);
+  }
+  return paneId;
+}
+
+function extractHerdrText(result: unknown): string {
+  // pane read may return a {text: "..."} object, a {content: "..."} object,
+  // or a raw string (if the CLI ever emits plain text). Be defensive.
+  if (typeof result === "string") return result;
+  if (result && typeof result === "object") {
+    const obj = result as { text?: unknown; content?: unknown; output?: unknown; lines?: unknown };
+    if (typeof obj.text === "string") return obj.text;
+    if (typeof obj.content === "string") return obj.content;
+    if (typeof obj.output === "string") return obj.output;
+    if (Array.isArray(obj.lines)) return obj.lines.filter((l) => typeof l === "string").join("\n");
+  }
+  // Unknown shape — stringify so caller sees SOMETHING rather than hanging.
+  return JSON.stringify(result);
 }
 
 function zellijPaneId(surface: string): string {
@@ -263,6 +351,25 @@ export function createSurfaceSplit(
 ): string {
   const backend = requireMuxBackend();
 
+  if (backend === "herdr") {
+    // Each subagent goes in its own tab. Use the caller-supplied name as-is
+    // for both the tab label and (via PI_SUBAGENT_NAME in the spawned pi's
+    // herdr-agent-state) the sidebar agent label. Callers are expected to
+    // pass short, descriptive names like `scout.auth` — see the subagent
+    // tool description. `direction` is a no-op — tabs don't split layouts
+    // directionally.
+    const tabLabel = name?.trim() || "subagent";
+    const createArgs = ["tab", "create", "--cwd", process.cwd(), "--label", tabLabel];
+    const result = herdrRpc(createArgs) as { root_pane?: { pane_id?: string } } | null;
+    const paneId = result?.root_pane?.pane_id;
+    if (!paneId) {
+      throw new Error(
+        `herdr tab create: missing root_pane.pane_id in ${JSON.stringify(result)}`,
+      );
+    }
+    return paneId;
+  }
+
   if (backend === "cmux") {
     const surfaceArg = fromSurface ? ` --surface ${shellEscape(fromSurface)}` : "";
     const out = execSync(`cmux new-split ${direction}${surfaceArg}`, {
@@ -377,6 +484,14 @@ export function createSurfaceSplit(
 export function renameCurrentTab(title: string): void {
   const backend = requireMuxBackend();
 
+  if (backend === "herdr") {
+    // No-op. Tab labels we own are set at spawn time via createSurfaceSplit
+    // (for subagents in their own tabs). Renaming the parent pi's tab mid-
+    // session — e.g. during /plan — would clobber the herdr-assigned cwd
+    // label unnecessarily. Subagent identity surfaces via sidebar agent.
+    return;
+  }
+
   if (backend === "cmux") {
     const surfaceId = process.env.CMUX_SURFACE_ID;
     if (!surfaceId) throw new Error("CMUX_SURFACE_ID not set");
@@ -424,6 +539,13 @@ export function renameCurrentTab(title: string): void {
  */
 export function renameWorkspace(title: string): void {
   const backend = requireMuxBackend();
+
+  if (backend === "herdr") {
+    // No-op. herdr workspaces are long-lived and their default label (the
+    // cwd) is more useful than ephemeral plan/session titles. Plan and
+    // subagent identity surface via tab labels and per-pane agent state.
+    return;
+  }
 
   if (backend === "cmux") {
     execSync(`cmux workspace-action --action rename --title ${shellEscape(title)}`, {
@@ -478,6 +600,14 @@ export function renameWorkspace(title: string): void {
 export function sendCommand(surface: string, command: string): void {
   const backend = requireMuxBackend();
 
+  if (backend === "herdr") {
+    // Match the cmux/wezterm pattern: embed the newline in the text payload.
+    // A literal \n at the end of send-text lets the shell treat the line as
+    // submitted without a separate send-keys round-trip.
+    herdrRpc(["pane", "send-text", surface, command + "\n"]);
+    return;
+  }
+
   if (backend === "cmux") {
     execSync(`cmux send --surface ${shellEscape(surface)} ${shellEscape(command + "\n")}`, {
       encoding: "utf8",
@@ -509,6 +639,11 @@ export function sendCommand(surface: string, command: string): void {
  */
 export function sendEscape(surface: string): void {
   const backend = requireMuxBackend();
+
+  if (backend === "herdr") {
+    herdrRpc(["pane", "send-keys", surface, "Escape"]);
+    return;
+  }
 
   if (backend === "cmux") {
     execFileSync("cmux", ["send", "--surface", surface, "\u001b"], { encoding: "utf8" });
@@ -574,6 +709,11 @@ export function sendLongCommand(
 export function readScreen(surface: string, lines = 50): string {
   const backend = requireMuxBackend();
 
+  if (backend === "herdr") {
+    const result = herdrRpc(["pane", "read", surface, "--source", "recent"]);
+    return tailLines(extractHerdrText(result), Math.max(lines, HERDR_MIN_TAIL_LINES));
+  }
+
   if (backend === "cmux") {
     return execSync(`cmux read-screen --surface ${shellEscape(surface)} --lines ${lines}`, {
       encoding: "utf8",
@@ -617,6 +757,11 @@ export function readScreen(surface: string, lines = 50): string {
 export async function readScreenAsync(surface: string, lines = 50): Promise<string> {
   const backend = requireMuxBackend();
 
+  if (backend === "herdr") {
+    const result = await herdrRpcAsync(["pane", "read", surface, "--source", "recent"]);
+    return tailLines(extractHerdrText(result), Math.max(lines, HERDR_MIN_TAIL_LINES));
+  }
+
   if (backend === "cmux") {
     const { stdout } = await execFileAsync(
       "cmux",
@@ -659,6 +804,24 @@ export async function readScreenAsync(surface: string, lines = 50): Promise<stri
  */
 export function closeSurface(surface: string): void {
   const backend = requireMuxBackend();
+
+  if (backend === "herdr") {
+    // Subagents live in their own tab (see createSurfaceSplit). Close the
+    // whole tab so the tab bar stays tidy. Fallback to pane close if the
+    // tab_id can't be resolved (e.g. pane was moved elsewhere).
+    try {
+      const info = herdrRpc(["pane", "get", surface]) as { pane?: { tab_id?: string } } | null;
+      const tabId = info?.pane?.tab_id;
+      if (tabId) {
+        herdrRpc(["tab", "close", tabId]);
+        return;
+      }
+    } catch {
+      // Fall through to pane close.
+    }
+    herdrRpc(["pane", "close", surface]);
+    return;
+  }
 
   if (backend === "cmux") {
     execSync(`cmux close-surface --surface ${shellEscape(surface)}`, {

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -76,7 +76,10 @@ function getModuleAbortSignal(): AbortSignal {
 }
 
 const SubagentParams = Type.Object({
-  name: Type.String({ description: "Display name for the subagent" }),
+  name: Type.String({
+    description:
+      "Short, descriptive display name for the subagent. Used as the multiplexer tab label, so keep it compact and disambiguate when multiple subagents of the same kind run in parallel.",
+  }),
   task: Type.String({ description: "Task/prompt for the sub-agent" }),
   agent: Type.Optional(
     Type.String({
@@ -461,6 +464,36 @@ interface RunningSubagent {
 
 /** All currently running subagents, keyed by id. */
 const runningSubagents = new Map<string, RunningSubagent>();
+
+/**
+ * Emit lifecycle events ({@link `subagents:started`} / {@link `subagents:ended`})
+ * alongside mutations of `runningSubagents`. Other extensions (herdr state
+ * reporters, per-pane widgets, metrics) can react without needing to reach
+ * into our internal Map.
+ *
+ * Populated by the default export once the extension initializes. Events
+ * emitted before init are dropped silently.
+ */
+let emitSubagentLifecycle: ((type: "started" | "ended", running: RunningSubagent) => void) | null = null;
+
+function addRunningSubagent(running: RunningSubagent): void {
+  runningSubagents.set(running.id, running);
+  emitSubagentLifecycle?.("started", running);
+}
+
+function removeRunningSubagent(id: string): void {
+  const entry = runningSubagents.get(id);
+  if (!entry) return;
+  runningSubagents.delete(id);
+  emitSubagentLifecycle?.("ended", entry);
+}
+
+function clearRunningSubagents(): void {
+  for (const [, entry] of runningSubagents) {
+    emitSubagentLifecycle?.("ended", entry);
+  }
+  runningSubagents.clear();
+}
 
 // ── Widget management ──
 
@@ -957,7 +990,7 @@ async function launchSubagent(
       }),
     };
 
-    runningSubagents.set(id, running);
+    addRunningSubagent(running);
     return running;
   }
 
@@ -1102,7 +1135,7 @@ async function launchSubagent(
     }),
   };
 
-  runningSubagents.set(id, running);
+  addRunningSubagent(running);
   return running;
 }
 
@@ -1181,7 +1214,7 @@ async function watchSubagent(
       }
 
       closeSurface(surface);
-      runningSubagents.delete(running.id);
+      removeRunningSubagent(running.id);
 
       return { name, task, summary, exitCode: result.exitCode, elapsed, ...(sessionId ? { claudeSessionId: sessionId } : {}) };
     }
@@ -1203,7 +1236,7 @@ async function watchSubagent(
     }
 
     closeSurface(surface);
-    runningSubagents.delete(running.id);
+    removeRunningSubagent(running.id);
 
     return {
       name,
@@ -1218,7 +1251,7 @@ async function watchSubagent(
     try {
       closeSurface(surface);
     } catch {}
-    runningSubagents.delete(running.id);
+    removeRunningSubagent(running.id);
 
     if (signal.aborted) {
       return {
@@ -1243,6 +1276,21 @@ async function watchSubagent(
 }
 
 export default function subagentsExtension(pi: ExtensionAPI) {
+  // Expose subagent lifecycle as pi events so other extensions (herdr state
+  // reporters, per-pane widgets, metrics) can react without reaching into
+  // our internal Map. Emitted events:
+  //   subagents:started — { id, name, agent, task, surface }
+  //   subagents:ended   — { id, name, agent, task, surface }
+  emitSubagentLifecycle = (type, running) => {
+    pi.events.emit(`subagents:${type}`, {
+      id: running.id,
+      name: running.name,
+      agent: running.agent,
+      task: running.task,
+      surface: running.surface,
+    });
+  };
+
   // Capture the UI context for widget updates
   pi.on("session_start", (_event, ctx) => {
     latestCtx = ctx;
@@ -1265,7 +1313,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     for (const [_id, agent] of runningSubagents) {
       agent.abortController?.abort();
     }
-    runningSubagents.clear();
+    clearRunningSubagents();
   });
 
   // Tools denied via PI_DENY_TOOLS env var (set by parent agent based on frontmatter)
@@ -1758,7 +1806,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
             baselineBytes: initialProgress?.bytes,
           }),
         };
-        runningSubagents.set(id, running);
+        addRunningSubagent(running);
         startWidgetRefresh();
         startStatusRefresh(pi);
 


### PR DESCRIPTION
Adds [herdr](https://github.com/ogulcancelik/herdr) (terminal workspace manager for AI coding agents) as a first-class multiplexer backend alongside cmux/tmux/zellij/wezterm, plus a small complementary API addition.

Demo: https://www.loom.com/share/d67407222a7a4f759aa64fb15e74f634

## Herdr backend

Activates when `HERDR_ENV=1` and the `herdr` CLI is on PATH. When multiple multiplexers are available, herdr takes precedence — running pi inside herdr gets you herdr panes instead of wezterm tabs / tmux panes.

- Every backend-dispatched function in `cmux.ts` (`createSurfaceSplit`, `sendCommand`, `sendEscape`, `readScreen[Async]`, `closeSurface`, `renameCurrentTab`, `renameWorkspace`) gets a herdr branch that shells out to the `herdr` CLI — matching the pattern used for wezterm/tmux.
- Each subagent spawns into its own tab via `herdr tab create --label`, so the tab bar surfaces the subagent's name cleanly. `closeSurface` closes the whole tab.
- herdr only supports `right|down` splits; `left`→`right` and `up`→`down` are mapped silently.
- `renameWorkspace` and `renameCurrentTab` are no-ops for herdr — herdr workspaces and the user's main tab are stable defaults; plan/subagent identity surfaces via tab labels set at spawn time.
- CLI output is a JSON-RPC-ish envelope (`{id, result|error, type}`). A small `parseHerdrEnvelope` handles JSON error envelopes and plain-text responses (`pane read` emits plain text; action commands emit empty stdout on success).
- `readScreen[Async]` fetches the full recent buffer with a 50-line tail floor locally; capping herdr's `--lines` at the caller's small N (e.g. `5` for `pollForExit`) would miss the exit sentinel once multi-line shell prompts push it past line N.

## Subagent lifecycle events (general-purpose)

Independent of herdr — adds two events that any integration extension (state reporters, metrics, per-pane widgets) can listen on:

- `pi.events.emit("subagents:started", {id, name, agent, task, surface})`
- `pi.events.emit("subagents:ended", {id, name, agent, task, surface})`

Emitted from centralized helpers (`addRunningSubagent`, `removeRunningSubagent`, `clearRunningSubagents`) replacing direct `runningSubagents` Map mutations at every spawn/cleanup site. The motivating use case: a herdr state reporter that keeps reporting `working` to the multiplexer while subagents are outstanding — without this signal it flipped to `idle` the instant the `subagent` tool call returned, firing spurious "agent finished" notifications.

## Small related touch-up

The `subagent` tool's `name` parameter description now hints that it's used as the multiplexer tab label, so callers pick compact, disambiguated display names when spawning multiple parallel subagents.

## Testing

Tested against herdr 0.5.0 on Linux with the `worker` and `/plan` flows end-to-end. All existing tests (77/77) still pass.

## Question for you

Interested in upstreaming this? I've been running it on my own config for a few days; happy to keep battle-testing and refining based on your feedback before moving out of draft. If it's out of scope for the project, totally understand — I'll maintain it out of tree.