### PR TITLE
fix: replace subagent liveness polling with child activity state

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ https://github.com/user-attachments/assets/30adb156-cfb4-4c47-84ca-dd4aa80cba9f
 
 ## How It Works
 
-Call `subagent()` and it **returns immediately**. The sub-agent runs in its own terminal pane. A live widget above the input shows all running agents with their current state — `active`, `quiet`, `stalled`, or `starting`. When a sub-agent finishes, its result is **steered back** into the main session as an async notification — triggering a new turn so the agent can process it.
+Call `subagent()` and it **returns immediately**. The sub-agent runs in its own terminal pane. A live widget above the input shows all running agents with their current state — `starting`, `active`, `waiting`, `stalled`, or `running`. When a sub-agent finishes, its result is **steered back** into the main session as an async notification — triggering a new turn so the agent can process it.
 
 ```
-╭─ Subagents ────────────────────────── 2 running ─╮
-│ 00:23  Scout: Auth (scout)       active · 8 msgs │
-│ 00:45  Scout: DB (scout)                quiet 2m │
-╰──────────────────────────────────────────────────╯
+╭─ Subagents ──────────────────────────── 2 running ─╮
+│ 00:23  Scout: Auth (scout)        active · bash 7m │
+│ 00:45  Scout: DB (scout)                waiting 2m │
+╰────────────────────────────────────────────────────╯
 ```
 
 For parallel execution, just call `subagent` multiple times — they all run concurrently:
@@ -102,32 +102,32 @@ Agent discovery follows priority: **project-local** (`.pi/agents/`) > **global**
 Multiple subagents run concurrently — each steers its result back independently as it finishes. The live widget above the input tracks all running agents:
 
 ```
-╭─ Subagents ─────────────────────────── 3 running ─╮
-│ 01:23  Scout: Auth (scout)       active · 15 msgs │
-│ 00:45  Researcher (researcher)         stalled 4m │
-│ 00:12  Scout: DB (scout)                starting… │
-╰───────────────────────────────────────────────────╯
+╭─ Subagents ───────────────────────────────── 3 running ─╮
+│ 01:23  Scout: Auth (scout)            active · write 7m │
+│ 00:45  Researcher (researcher)               stalled 4m │
+│ 00:12  Scout: DB (scout)                      starting… │
+╰─────────────────────────────────────────────────────────╯
 ```
 
 Completion messages render with a colored background and are expandable with `Ctrl+O` to show the full summary and session file path.
 
 ### In-progress status updates
 
-The widget tracks each sub-agent's progress and labels it with a coarse state:
+The widget tracks each Pi-backed sub-agent from a child-written runtime snapshot and labels it with a coarse state:
 
-- `starting` — launched, but no progress observed yet
-- `active` — recent progress observed
-- `quiet` — still running, but no recent progress
-- `stalled` — no progress for an extended period
-- `running` — fallback for backends without progress tracking (e.g. Claude)
+- `starting` — launched, but no valid child snapshot has been observed yet
+- `active` — the child is doing observed runtime work: agent turn, provider request, streaming, or tool execution
+- `waiting` — the child finished a turn and is intentionally open for more input or another stage
+- `stalled` — the parent has gone too long without a valid current child snapshot and can no longer trust the run is healthy
+- `running` — fallback for backends without child snapshots (e.g. Claude)
 
-These labels are derived from session-file activity. The `defaultCadenceSeconds` setting controls the idle-time thresholds: with the default of `60`, a run becomes `quiet` after about 1 minute without progress and `stalled` after about 3 minutes. When a run enters `stalled` or recovers from it, the parent agent receives a steer message so it can react. All other status transitions stay in the widget only.
+These labels are no longer derived from session-file growth. Session JSONL is still used for transcript, resume, lineage, and result extraction, but Pi-backed liveness now comes from a small activity snapshot written by the child extension. A fixed internal watchdog marks a run as `stalled` when valid snapshots never appear, stop being readable, or stop matching the current child; valid long-running `active` or `waiting` states do not become `stalled` just because time passes. When a run enters `stalled` or recovers from it, the parent agent receives a steer message so it can react. All other status transitions stay in the widget only.
 
-**Interactive subagents stay silent.** Long-running user-driven subagents (e.g. `planner`, or any `/iterate` fork) do not wake the parent session on `stalled`/`recovered` transitions — the user is working directly in the subagent's pane, and a steer message there would just burn an orchestrator turn on a no-op "still waiting" ping. The widget still updates normally. By default, agents with `auto-exit: true` are treated as autonomous and get stall pings; agents without it are treated as interactive and stay quiet. Override per-agent with `interactive: true|false` in frontmatter, or per-spawn with `interactive: true|false` on the tool call.
+**Interactive subagents stay silent.** Long-running user-driven subagents (e.g. `planner`, or any `/iterate` fork) do not wake the parent session on `stalled`/`recovered` transitions — the user is working directly in the subagent's pane, and a steer message there would just burn an orchestrator turn on a no-op "still waiting" ping. The widget still updates normally, and child snapshots are still recorded/classified regardless of the `interactive` setting. By default, agents with `auto-exit: true` are treated as autonomous and get stall pings; agents without it are treated as interactive and stay quiet. Override per-agent with `interactive: true|false` in frontmatter, or per-spawn with `interactive: true|false` on the tool call.
 
 #### Configuration
 
-Status defaults come from `config.json` in the extension directory. Copy `config.json.example` to get started:
+Status display is controlled by `config.json` in the extension directory. Copy `config.json.example` to get started:
 
 ```bash
 cp config.json.example config.json
@@ -136,22 +136,12 @@ cp config.json.example config.json
 ```json
 {
   "status": {
-    "enabled": true,
-    "defaultCadenceSeconds": 60
+    "enabled": true
   }
 }
 ```
 
-`config.json` is gitignored so local overrides don't get committed. You can also override per run:
-
-```typescript
-subagent({
-  name: "Scout",
-  agent: "scout",
-  statusCadenceSeconds: 30,
-  task: "Analyze the auth module",
-});
-```
+`config.json` is gitignored so local overrides don't get committed.
 
 ---
 
@@ -169,9 +159,6 @@ subagent({ name: "Planner", agent: "planner", task: "Work through the design wit
 
 // Custom working directory
 subagent({ name: "Designer", agent: "game-designer", cwd: "agents/game-designer", task: "..." });
-
-// Override the status classification window for this run
-subagent({ name: "Scout", agent: "scout", statusCadenceSeconds: 30, task: "..." });
 ```
 
 ### Parameters
@@ -188,7 +175,6 @@ subagent({ name: "Scout", agent: "scout", statusCadenceSeconds: 30, task: "..." 
 | `skills`               | string  | —              | Comma-separated skill names                                                                       |
 | `tools`                | string  | —              | Comma-separated tool names                                                                        |
 | `cwd`                  | string  | —              | Working directory for the sub-agent (see [Role Folders](#role-folders))                           |
-| `statusCadenceSeconds` | number  | config default | Idle-time window for status classification (has a minimum floor)                                  |
 
 ---
 
@@ -202,7 +188,7 @@ subagent_interrupt({ id: "abcd1234" });
 subagent_interrupt({ name: "Scout" });
 ```
 
-This sends Escape to the child pane, cancelling the in-progress model turn. The subagent session stays alive — the pane, session file, and background polling all remain intact. After the interrupt, the widget shows the child as `quiet`. If the child makes new progress later, it returns to `active`; completion, failure, and `caller_ping` still flow through normally.
+This sends Escape to the child pane, cancelling the in-progress model turn. The subagent session stays alive — the pane, session file, and background polling all remain intact. After the interrupt, the widget immediately moves the child back to `waiting`, and stale pre-interrupt snapshots are ignored. If the child starts work later, newer snapshots return it to `active`; completion, failure, and `caller_ping` still flow through normally.
 
 This is a turn-level interrupt, not a method for forcibly terminating a subagent session.
 
@@ -364,7 +350,7 @@ Controls whether status transitions (`stalled`, `recovered`) wake the parent ses
 
 **Default:** the inverse of `auto-exit`. Autonomous agents (`auto-exit: true`) are non-interactive and ping the parent on stall/recovery; agents without `auto-exit` are interactive and stay quiet. Bare spawns with no agent defs (e.g. `/iterate` with `fork: true`) are treated as interactive.
 
-**Why it exists:** Interactive agents can run for minutes or hours while the user thinks, types, and reads in the subagent's pane. Those natural pauses trip the `stalled` classifier — but the parent session has nothing useful to do with that information, and every transition costs an orchestrator turn. Skipping the steer keeps the parent quiet until the child actually finishes.
+**Why it exists:** Interactive agents can run for minutes or hours while the user thinks, types, and reads in the subagent's pane. Child snapshots still update the widget, but stalled/recovered supervision messages rarely need to wake the parent for user-driven sessions. Skipping the steer keeps the parent quiet until the child actually finishes.
 
 **When to override:**
 

--- a/config.json.example
+++ b/config.json.example
@@ -1,6 +1,5 @@
 {
   "status": {
-    "enabled": true,
-    "defaultCadenceSeconds": 60
+    "enabled": true
   }
 }

--- a/pi-extension/subagents/activity.ts
+++ b/pi-extension/subagents/activity.ts
@@ -1,0 +1,511 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export type SubagentActivityPhase = "starting" | "active" | "waiting" | "done";
+export type SubagentActivityScope = "agent" | "turn" | "provider" | "streaming" | "tool";
+
+export type SubagentActivityEvent =
+  | "session_start"
+  | "input"
+  | "before_agent_start"
+  | "agent_start"
+  | "agent_end"
+  | "turn_start"
+  | "turn_end"
+  | "before_provider_request"
+  | "after_provider_response"
+  | "message_update"
+  | "tool_execution_start"
+  | "tool_call"
+  | "tool_execution_update"
+  | "tool_result"
+  | "tool_execution_end"
+  | "caller_ping"
+  | "subagent_done"
+  | "session_shutdown";
+
+export interface SubagentActivityState {
+  version: 1;
+  runningChildId: string;
+  createdAt: number;
+  updatedAt: number;
+  sequence: number;
+  latestEvent: SubagentActivityEvent;
+  phase: SubagentActivityPhase;
+  agentActive: boolean;
+  turnActive: boolean;
+  providerActive: boolean;
+  toolActive: boolean;
+  activeScope?: SubagentActivityScope;
+  activeSince?: number;
+  waitingSince?: number;
+  turnIndex?: number;
+  messageEventType?: string;
+  toolCallId?: string;
+  toolName?: string;
+  toolStartedAt?: number;
+  toolEndedAt?: number;
+}
+
+export type ActivityReadResult =
+  | { ok: true; activity: SubagentActivityState }
+  | { ok: false; reason: "missing" | "invalid" | "wrong-id"; error?: string };
+
+export type SubagentShutdownReason = "quit" | "reload" | "new" | "resume" | "fork";
+
+export interface SubagentActivityRecorder {
+  sessionStart(): void;
+  input(): void;
+  beforeAgentStart(): void;
+  agentStart(): void;
+  agentEndWaiting(): void;
+  agentEndDone(): void;
+  turnStart(turnIndex?: number): void;
+  turnEnd(turnIndex?: number): void;
+  beforeProviderRequest(): void;
+  afterProviderResponse(): void;
+  messageUpdate(messageEventType?: string): void;
+  toolExecutionStart(toolCallId?: string, toolName?: string): void;
+  toolCall(toolCallId?: string, toolName?: string): void;
+  toolExecutionUpdate(toolCallId?: string, toolName?: string): void;
+  toolResult(toolCallId?: string, toolName?: string): void;
+  toolExecutionEnd(toolCallId?: string, toolName?: string): void;
+  callerPing(): void;
+  subagentDone(): void;
+  sessionShutdown(reason: SubagentShutdownReason): void;
+}
+
+const ACTIVITY_UPDATE_THROTTLE_MS = 500;
+const MAX_WRITE_FAILURES = 3;
+const KNOWN_PHASES = new Set<SubagentActivityPhase>(["starting", "active", "waiting", "done"]);
+const KNOWN_SCOPES = new Set<SubagentActivityScope>(["agent", "turn", "provider", "streaming", "tool"]);
+const KNOWN_EVENTS = new Set<SubagentActivityEvent>([
+  "session_start",
+  "input",
+  "before_agent_start",
+  "agent_start",
+  "agent_end",
+  "turn_start",
+  "turn_end",
+  "before_provider_request",
+  "after_provider_response",
+  "message_update",
+  "tool_execution_start",
+  "tool_call",
+  "tool_execution_update",
+  "tool_result",
+  "tool_execution_end",
+  "caller_ping",
+  "subagent_done",
+  "session_shutdown",
+]);
+const MAX_ACTIVITY_STRING_LENGTH = 200;
+
+export function getSubagentActivityFile(artifactDir: string, runningChildId: string): string {
+  return join(artifactDir, "subagent-activity", `${runningChildId}.json`);
+}
+
+function requireObject(value: unknown): Record<string, unknown> | null {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function validateFiniteNumber(object: Record<string, unknown>, fieldName: string): string | null {
+  return Number.isFinite(object[fieldName]) ? null : `${fieldName} must be finite`;
+}
+
+function validateOptionalFiniteNumber(object: Record<string, unknown>, fieldName: string): string | null {
+  const value = object[fieldName];
+  return value == null || Number.isFinite(value) ? null : `${fieldName} must be finite when present`;
+}
+
+function validateInteger(object: Record<string, unknown>, fieldName: string): string | null {
+  return Number.isInteger(object[fieldName]) ? null : `${fieldName} must be an integer`;
+}
+
+function validateOptionalInteger(object: Record<string, unknown>, fieldName: string): string | null {
+  const value = object[fieldName];
+  return value == null || Number.isInteger(value) ? null : `${fieldName} must be an integer when present`;
+}
+
+function validateBoolean(object: Record<string, unknown>, fieldName: string): string | null {
+  return typeof object[fieldName] === "boolean" ? null : `${fieldName} must be a boolean`;
+}
+
+function validateOptionalActivityString(object: Record<string, unknown>, fieldName: string): string | null {
+  const value = object[fieldName];
+  if (value == null) return null;
+  if (typeof value !== "string") return `${fieldName} must be a string when present`;
+  if (/\r|\n/.test(value)) return `${fieldName} must not contain newlines`;
+  return value.length <= MAX_ACTIVITY_STRING_LENGTH ? null : `${fieldName} is too long`;
+}
+
+function invalidActivity(error: string): ActivityReadResult {
+  return { ok: false, reason: "invalid", error };
+}
+
+function validateActivity(value: unknown, expectedRunningChildId: string): ActivityReadResult {
+  const object = requireObject(value);
+  if (!object) return invalidActivity("activity must be an object");
+  if (object.version !== 1) return invalidActivity("unsupported activity version");
+  if (typeof object.runningChildId !== "string") return invalidActivity("runningChildId must be a string");
+  if (object.runningChildId !== expectedRunningChildId) return { ok: false, reason: "wrong-id" };
+  if (typeof object.latestEvent !== "string" || !KNOWN_EVENTS.has(object.latestEvent as SubagentActivityEvent)) {
+    return invalidActivity("unknown latestEvent");
+  }
+  if (typeof object.phase !== "string" || !KNOWN_PHASES.has(object.phase as SubagentActivityPhase)) {
+    return invalidActivity("unknown activity phase");
+  }
+  if (
+    object.activeScope != null &&
+    (typeof object.activeScope !== "string" || !KNOWN_SCOPES.has(object.activeScope as SubagentActivityScope))
+  ) {
+    return invalidActivity("unknown activeScope");
+  }
+
+  const validationError = [
+    validateFiniteNumber(object, "createdAt"),
+    validateFiniteNumber(object, "updatedAt"),
+    validateInteger(object, "sequence"),
+    validateBoolean(object, "agentActive"),
+    validateBoolean(object, "turnActive"),
+    validateBoolean(object, "providerActive"),
+    validateBoolean(object, "toolActive"),
+    validateOptionalFiniteNumber(object, "activeSince"),
+    validateOptionalFiniteNumber(object, "waitingSince"),
+    validateOptionalInteger(object, "turnIndex"),
+    validateOptionalFiniteNumber(object, "toolStartedAt"),
+    validateOptionalFiniteNumber(object, "toolEndedAt"),
+    validateOptionalActivityString(object, "messageEventType"),
+    validateOptionalActivityString(object, "toolCallId"),
+    validateOptionalActivityString(object, "toolName"),
+  ].find((error) => error != null);
+  if (validationError) return invalidActivity(validationError);
+
+  return { ok: true, activity: object as unknown as SubagentActivityState };
+}
+
+export function readSubagentActivityFile(
+  activityFile: string,
+  expectedRunningChildId: string,
+): ActivityReadResult {
+  if (!existsSync(activityFile)) return { ok: false, reason: "missing" };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(activityFile, "utf8"));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, reason: "invalid", error: message };
+  }
+
+  return validateActivity(parsed, expectedRunningChildId);
+}
+
+export function writeSubagentActivityFile(activityFile: string, activity: SubagentActivityState): void {
+  const dir = dirname(activityFile);
+  mkdirSync(dir, { recursive: true });
+  const tempFile = join(dir, `${activity.runningChildId}.json.${process.pid}.${activity.sequence}.tmp`);
+
+  try {
+    writeFileSync(tempFile, `${JSON.stringify(activity)}\n`, "utf8");
+    renameSync(tempFile, activityFile);
+  } catch (error) {
+    try {
+      unlinkSync(tempFile);
+    } catch (cleanupError) {
+      // Temp cleanup is best effort; preserve the original write/rename failure
+      void cleanupError;
+    }
+    throw error;
+  }
+}
+
+function createNoopRecorder(): SubagentActivityRecorder {
+  return {
+    sessionStart() {},
+    input() {},
+    beforeAgentStart() {},
+    agentStart() {},
+    agentEndWaiting() {},
+    agentEndDone() {},
+    turnStart() {},
+    turnEnd() {},
+    beforeProviderRequest() {},
+    afterProviderResponse() {},
+    messageUpdate() {},
+    toolExecutionStart() {},
+    toolCall() {},
+    toolExecutionUpdate() {},
+    toolResult() {},
+    toolExecutionEnd() {},
+    callerPing() {},
+    subagentDone() {},
+    sessionShutdown() {},
+  };
+}
+
+function clearActiveState(activity: SubagentActivityState): void {
+  activity.agentActive = false;
+  activity.turnActive = false;
+  activity.providerActive = false;
+  activity.toolActive = false;
+  delete activity.activeScope;
+  delete activity.activeSince;
+}
+
+function refreshActiveScope(activity: SubagentActivityState): void {
+  if (activity.toolActive) {
+    activity.phase = "active";
+    activity.activeScope = "tool";
+    return;
+  }
+  if (activity.providerActive) {
+    activity.phase = "active";
+    activity.activeScope = "provider";
+    return;
+  }
+  if (activity.turnActive) {
+    activity.phase = "active";
+    activity.activeScope = "turn";
+    return;
+  }
+  if (activity.agentActive) {
+    activity.phase = "active";
+    activity.activeScope = "agent";
+    return;
+  }
+  delete activity.activeScope;
+  delete activity.activeSince;
+}
+
+function markActive(
+  activity: SubagentActivityState,
+  scope: SubagentActivityScope,
+  now: number,
+  resetActiveSince = false,
+): void {
+  activity.phase = "active";
+  activity.activeScope = scope;
+  if (activity.activeSince == null || resetActiveSince) activity.activeSince = now;
+  delete activity.waitingSince;
+}
+
+export function createSubagentActivityRecorder(params: {
+  runningChildId?: string;
+  activityFile?: string;
+  now?: () => number;
+}): SubagentActivityRecorder {
+  const runningChildId = params.runningChildId?.trim();
+  const activityFile = params.activityFile?.trim();
+  if (!runningChildId || !activityFile) return createNoopRecorder();
+
+  const now = params.now ?? (() => Date.now());
+  const createdAt = now();
+  const activity: SubagentActivityState = {
+    version: 1,
+    runningChildId,
+    createdAt,
+    updatedAt: createdAt,
+    sequence: 0,
+    latestEvent: "session_start",
+    phase: "starting",
+    agentActive: false,
+    turnActive: false,
+    providerActive: false,
+    toolActive: false,
+  };
+
+  let disabled = false;
+  let failureCount = 0;
+  let lastFlushAt = 0;
+  let pendingFlush: ReturnType<typeof setTimeout> | null = null;
+
+  function clearPendingFlush(): void {
+    if (!pendingFlush) return;
+    clearTimeout(pendingFlush);
+    pendingFlush = null;
+  }
+
+  function disable(): void {
+    disabled = true;
+    clearPendingFlush();
+  }
+
+  function flushNow(): void {
+    if (disabled) return;
+    try {
+      writeSubagentActivityFile(activityFile, activity);
+      lastFlushAt = now();
+      failureCount = 0;
+    } catch {
+      failureCount += 1;
+      if (failureCount >= MAX_WRITE_FAILURES) disable();
+    }
+  }
+
+  function scheduleFlush(): void {
+    if (disabled || pendingFlush) return;
+
+    const remainingMs = Math.max(0, ACTIVITY_UPDATE_THROTTLE_MS - (now() - lastFlushAt));
+    if (remainingMs === 0) {
+      flushNow();
+      return;
+    }
+
+    pendingFlush = setTimeout(() => {
+      pendingFlush = null;
+      flushNow();
+    }, remainingMs);
+  }
+
+  function record(
+    latestEvent: SubagentActivityEvent,
+    update: (current: SubagentActivityState, now: number) => void,
+    flush: "immediate" | "throttled",
+  ): void {
+    if (disabled) return;
+    if (flush === "immediate") clearPendingFlush();
+
+    const observedAt = now();
+    activity.latestEvent = latestEvent;
+    activity.updatedAt = observedAt;
+    activity.sequence += 1;
+    update(activity, observedAt);
+
+    if (flush === "immediate") flushNow();
+    else scheduleFlush();
+  }
+
+  function markDone(latestEvent: SubagentActivityEvent): void {
+    record(latestEvent, (current) => {
+      current.phase = "done";
+      clearActiveState(current);
+      delete current.waitingSince;
+    }, "immediate");
+    disable();
+  }
+
+  return {
+    sessionStart() {
+      record("session_start", (current) => {
+        current.phase = "starting";
+        clearActiveState(current);
+        delete current.waitingSince;
+      }, "immediate");
+    },
+    input() {
+      record("input", () => {}, "immediate");
+    },
+    beforeAgentStart() {
+      record("before_agent_start", (current, observedAt) => {
+        current.agentActive = true;
+        markActive(current, "agent", observedAt);
+      }, "immediate");
+    },
+    agentStart() {
+      record("agent_start", (current, observedAt) => {
+        current.agentActive = true;
+        markActive(current, "agent", observedAt);
+      }, "immediate");
+    },
+    agentEndWaiting() {
+      record("agent_end", (current, observedAt) => {
+        clearActiveState(current);
+        current.phase = "waiting";
+        current.waitingSince = observedAt;
+      }, "immediate");
+    },
+    agentEndDone() {
+      markDone("agent_end");
+    },
+    turnStart(turnIndex) {
+      record("turn_start", (current, observedAt) => {
+        current.agentActive = true;
+        current.turnActive = true;
+        if (turnIndex != null) current.turnIndex = turnIndex;
+        markActive(current, current.toolActive || current.providerActive ? current.activeScope ?? "turn" : "turn", observedAt);
+      }, "immediate");
+    },
+    turnEnd(turnIndex) {
+      record("turn_end", (current) => {
+        current.turnActive = false;
+        current.providerActive = false;
+        current.toolActive = false;
+        if (turnIndex != null) current.turnIndex = turnIndex;
+        refreshActiveScope(current);
+      }, "immediate");
+    },
+    beforeProviderRequest() {
+      record("before_provider_request", (current, observedAt) => {
+        current.providerActive = true;
+        markActive(current, "provider", observedAt, true);
+      }, "immediate");
+    },
+    afterProviderResponse() {
+      record("after_provider_response", (current) => {
+        current.providerActive = false;
+        refreshActiveScope(current);
+      }, "immediate");
+    },
+    messageUpdate(messageEventType) {
+      record("message_update", (current, observedAt) => {
+        current.agentActive = true;
+        current.turnActive = true;
+        current.messageEventType = messageEventType;
+        if (!current.toolActive) markActive(current, "streaming", observedAt);
+      }, "throttled");
+    },
+    toolExecutionStart(toolCallId, toolName) {
+      record("tool_execution_start", (current, observedAt) => {
+        current.toolActive = true;
+        current.toolCallId = toolCallId;
+        current.toolName = toolName;
+        current.toolStartedAt = observedAt;
+        markActive(current, "tool", observedAt, true);
+      }, "immediate");
+    },
+    toolCall(toolCallId, toolName) {
+      record("tool_call", (current, observedAt) => {
+        current.toolActive = true;
+        current.toolCallId = toolCallId ?? current.toolCallId;
+        current.toolName = toolName ?? current.toolName;
+        markActive(current, "tool", observedAt);
+      }, "immediate");
+    },
+    toolExecutionUpdate(toolCallId, toolName) {
+      record("tool_execution_update", (current, observedAt) => {
+        current.toolActive = true;
+        current.toolCallId = toolCallId ?? current.toolCallId;
+        current.toolName = toolName ?? current.toolName;
+        markActive(current, "tool", observedAt);
+      }, "throttled");
+    },
+    toolResult(toolCallId, toolName) {
+      record("tool_result", (current) => {
+        current.toolCallId = toolCallId ?? current.toolCallId;
+        current.toolName = toolName ?? current.toolName;
+        refreshActiveScope(current);
+      }, "immediate");
+    },
+    toolExecutionEnd(toolCallId, toolName) {
+      record("tool_execution_end", (current, observedAt) => {
+        current.toolActive = false;
+        current.toolCallId = toolCallId ?? current.toolCallId;
+        current.toolName = toolName ?? current.toolName;
+        current.toolEndedAt = observedAt;
+        refreshActiveScope(current);
+      }, "immediate");
+    },
+    callerPing() {
+      markDone("caller_ping");
+    },
+    subagentDone() {
+      markDone("subagent_done");
+    },
+    sessionShutdown(reason) {
+      if (reason === "quit") markDone("session_shutdown");
+      else disable();
+    },
+  };
+}

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -5,7 +5,6 @@ import { Box, Text, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import { dirname, join } from "node:path";
 import {
   readdirSync,
-  statSync,
   readFileSync,
   writeFileSync,
   existsSync,
@@ -30,7 +29,6 @@ import {
 } from "./cmux.ts";
 import {
   findLastAssistantMessage,
-  getEntryCount,
   getNewEntries,
   seedSubagentSessionFile,
 } from "./session.ts";
@@ -39,14 +37,20 @@ import {
   type SubagentStatusState,
   advanceStatusState,
   capStatusLines,
+  classifyStatus,
   createStatusState,
-  forceStatusQuiet,
+  forceStatusAfterInterrupt,
   formatStatusAggregate,
   formatTransitionLine,
   observeStatus,
   loadStatusConfig,
-  resolveStatusCadenceMs,
 } from "./status.ts";
+import {
+  getSubagentActivityFile,
+  readSubagentActivityFile,
+  type ActivityReadResult,
+  type SubagentActivityState,
+} from "./activity.ts";
 
 // Survive /reload: clear timers and abort poll loops from the previous module load.
 // /reload re-imports this file, giving fresh module-level state, but closures from
@@ -116,13 +120,6 @@ const SubagentParams = Type.Object({
     Type.String({
       description:
         "Resume a previous Claude Code session by its ID. Loads the conversation history and continues where it left off. The session ID is returned in details of every claude tool call. Use this to retry cancelled runs or ask follow-up questions.",
-    }),
-  ),
-  statusCadenceSeconds: Type.Optional(
-    Type.Integer({
-      minimum: 1,
-      description:
-        "Optional per-run idle-time window in seconds for active/quiet/stalled classification. Lower values are clamped to a safe minimum.",
     }),
   ),
 });
@@ -413,35 +410,25 @@ function getArtifactDir(sessionDir: string, sessionId: string): string {
   return join(sessionDir, "artifacts", sessionId);
 }
 
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes}B`;
-  const kb = bytes / 1024;
-  if (kb < 1024) return `${kb.toFixed(1)}KB`;
-  const mb = kb / 1024;
-  return `${mb.toFixed(1)}MB`;
-}
-
 const statusConfig = loadStatusConfig();
 
-function readSessionProgress(sessionFile: string): { entries: number; bytes: number } | null {
-  if (!existsSync(sessionFile)) return null;
-  const stat = statSync(sessionFile);
-  return {
-    entries: getEntryCount(sessionFile),
-    bytes: stat.size,
-  };
-}
-
-function buildWidgetRightLabel(agent: RunningSubagent, snapshot: StatusSnapshot): string {
+function formatWidgetRightLabel(snapshot: StatusSnapshot): string {
   if (snapshot.kind === "starting") return " starting… ";
   if (snapshot.kind === "running") return ` running ${snapshot.elapsedText} `;
   if (snapshot.kind === "active") {
-    if (agent.entries != null && agent.bytes != null) {
-      return ` active · ${agent.entries} msgs `;
-    }
-    return " active ";
+    const label = snapshot.activityLabel ?? snapshot.activeScope;
+    const duration = snapshot.activeDurationText ? ` ${snapshot.activeDurationText}` : "";
+    return label ? ` active · ${label}${duration} ` : " active ";
   }
-  return ` ${snapshot.kind} ${snapshot.idleText} `;
+  if (snapshot.kind === "waiting") {
+    const duration = snapshot.waitingDurationText ? ` ${snapshot.waitingDurationText}` : "";
+    const detail = snapshot.statusLabel ? ` · ${snapshot.statusLabel}` : "";
+    return ` waiting${duration}${detail} `;
+  }
+
+  const detail = snapshot.statusLabel ? ` · ${snapshot.statusLabel}` : "";
+  const duration = snapshot.snapshotProblemText ? ` ${snapshot.snapshotProblemText}` : "";
+  return ` stalled${detail}${duration} `;
 }
 
 function resolveResultPresentation(
@@ -484,8 +471,13 @@ interface RunningSubagent {
   startTime: number;
   sessionFile: string;
   launchScriptFile?: string;
-  entries?: number;
-  bytes?: number;
+  activityFile?: string;
+  activity?: SubagentActivityState;
+  activityRead?: {
+    ok: boolean;
+    reason?: "missing" | "invalid" | "wrong-id";
+    error?: string;
+  };
   abortController?: AbortController;
   cli?: string;
   sentinelFile?: string;
@@ -591,14 +583,12 @@ function renderSubagentWidgetLines(agents: RunningSubagent[], width: number): st
     const elapsed = formatElapsedMMSS(agent.startTime);
     const agentTag = agent.agent ? ` (${agent.agent})` : "";
     const left = ` ${elapsed}  ${agent.name}${agentTag} `;
-    const snapshot = advanceStatusState(agent.statusState, Date.now()).snapshot;
+    const snapshot = classifyStatus(agent.statusState, Date.now());
     const right = statusConfig.enabled
-      ? buildWidgetRightLabel(agent, snapshot)
-      : agent.entries != null && agent.bytes != null
-        ? ` ${agent.entries} msgs (${formatBytes(agent.bytes)}) `
-        : agent.cli === "claude"
-          ? " running… "
-          : " starting… ";
+      ? formatWidgetRightLabel(snapshot)
+      : agent.cli === "claude"
+        ? " running… "
+        : " starting… ";
 
     lines.push(borderLine(left, right, width));
   }
@@ -666,26 +656,47 @@ function buildPiPromptArgs(params: {
   ];
 }
 
-function isIgnorableSessionProgressError(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException | undefined)?.code;
-  return code === "ENOENT" || code === "EBUSY";
+function activityLabel(activity: SubagentActivityState): string | undefined {
+  if (activity.phase !== "active") return undefined;
+  if (activity.activeScope === "tool") return activity.toolName ?? "tool";
+  if (activity.activeScope === "provider") return "provider";
+  if (activity.activeScope === "streaming") return "streaming";
+  return activity.activeScope;
 }
 
 function observeRunningSubagent(running: RunningSubagent, observedAt = Date.now()) {
   if (running.cli === "claude") return;
 
-  try {
-    const progress = readSessionProgress(running.sessionFile);
-    if (!progress) return;
+  const activityFile = running.activityFile;
+  const read: ActivityReadResult = activityFile
+    ? readSubagentActivityFile(activityFile, running.id)
+    : { ok: false, reason: "missing" };
 
-    running.entries = progress.entries;
-    running.bytes = progress.bytes;
-    running.statusState = observeStatus(running.statusState, progress, observedAt);
-  } catch (error) {
-    // Ignore transient session-file races while the child is starting or appending.
-    // Unexpected errors should still fail fast.
-    if (!isIgnorableSessionProgressError(error)) throw error;
+  running.activityRead = read.ok
+    ? { ok: true }
+    : { ok: false, reason: read.reason, error: read.error };
+
+  if (read.ok) {
+    running.activity = read.activity;
+    running.statusState = observeStatus(running.statusState, {
+      snapshot: "present",
+      updatedAt: read.activity.updatedAt,
+      sequence: read.activity.sequence,
+      phase: read.activity.phase,
+      active: read.activity.phase === "active",
+      activeScope: read.activity.activeScope,
+      activeSince: read.activity.activeSince,
+      waitingSince: read.activity.waitingSince,
+      latestEvent: read.activity.latestEvent,
+      activityLabel: activityLabel(read.activity),
+    }, observedAt);
+    return;
   }
+
+  running.statusState = observeStatus(running.statusState, {
+    snapshot: read.reason,
+    snapshotError: read.error,
+  }, observedAt);
 }
 
 function resolveInterruptTarget(params: { id?: string; name?: string }):
@@ -753,6 +764,9 @@ function handleSubagentInterrupt(
     };
   }
 
+  const now = Date.now();
+  observeRunningSubagent(running, now);
+
   const interruption = requestSubagentInterrupt(running, sendEscapeKey);
   if ("error" in interruption) {
     return {
@@ -761,7 +775,7 @@ function handleSubagentInterrupt(
     };
   }
 
-  running.statusState = forceStatusQuiet(running.statusState, Date.now());
+  running.statusState = forceStatusAfterInterrupt(running.statusState, now);
   updateWidget();
 
   return {
@@ -788,6 +802,7 @@ function startStatusRefresh(pi: ExtensionAPI) {
     let shouldRefreshWidget = false;
 
     for (const running of runningSubagents.values()) {
+      observeRunningSubagent(running, now);
       const { nextState, snapshot, transition } = advanceStatusState(running.statusState, now);
       if (nextState.currentKind !== running.statusState.currentKind) {
         shouldRefreshWidget = true;
@@ -832,9 +847,8 @@ export const __test__ = {
   resolveLaunchBehavior,
   resolveEffectiveInteractive,
   buildPiPromptArgs,
-  buildWidgetRightLabel,
-  isIgnorableSessionProgressError,
-  readSessionProgress,
+  formatWidgetRightLabel,
+  observeRunningSubagent,
   resolveDenyTools,
   resolveInterruptTarget,
   requestSubagentInterrupt,
@@ -903,7 +917,6 @@ async function launchSubagent(
   }
 
   const launchBehavior = resolveLaunchBehavior(params, agentDefs);
-  const statusCadenceMs = resolveStatusCadenceMs(statusConfig, params.statusCadenceSeconds);
 
   if (launchBehavior.seededSessionMode) {
     seedSubagentSessionFile({
@@ -914,7 +927,8 @@ async function launchSubagent(
     });
   }
 
-  const initialProgress = readSessionProgress(subagentSessionFile);
+  const activityFile = getSubagentActivityFile(artifactDir, id);
+  mkdirSync(dirname(activityFile), { recursive: true });
   const { inheritsConversationContext } = launchBehavior;
 
   // Build the task message
@@ -952,7 +966,7 @@ async function launchSubagent(
       cmdParts.push("--model", shellEscape(effectiveModel));
     }
 
-    const sp = params.systemPrompt ?? agentDefs?.body;
+    const sp = params.systemPrompt ?? agentDefs.body;
     if (sp) {
       cmdParts.push("--append-system-prompt", shellEscape(sp));
     }
@@ -1000,7 +1014,6 @@ async function launchSubagent(
       statusState: createStatusState({
         source: "claude",
         startTimeMs: startTime,
-        cadenceMs: statusCadenceMs,
       }),
     };
 
@@ -1028,7 +1041,7 @@ async function launchSubagent(
   if (identityInSystemPrompt && identity) {
     const flag = systemPromptMode === "replace" ? "--system-prompt" : "--append-system-prompt";
     const spTimestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
-    const spSafeName = (params.name ?? "subagent")
+    const spSafeName = params.name
       .toLowerCase()
       .replace(/[^a-z0-9\s-]/g, "")
       .replace(/\s+/g, "-")
@@ -1073,6 +1086,8 @@ async function launchSubagent(
     envParts.push(`PI_SUBAGENT_AUTO_EXIT=1`);
   }
   envParts.push(`PI_SUBAGENT_SESSION=${shellEscape(subagentSessionFile)}`);
+  envParts.push(`PI_SUBAGENT_ID=${shellEscape(id)}`);
+  envParts.push(`PI_SUBAGENT_ACTIVITY_FILE=${shellEscape(activityFile)}`);
   envParts.push(`PI_SUBAGENT_SURFACE=${shellEscape(surface)}`);
   const envPrefix = envParts.join(" ") + " ";
 
@@ -1138,15 +1153,11 @@ async function launchSubagent(
     startTime,
     sessionFile: subagentSessionFile,
     launchScriptFile,
-    entries: initialProgress?.entries,
-    bytes: initialProgress?.bytes,
+    activityFile,
     interactive: effectiveInteractive,
     statusState: createStatusState({
       source: "pi",
       startTimeMs: startTime,
-      cadenceMs: statusCadenceMs,
-      baselineEntries: initialProgress?.entries,
-      baselineBytes: initialProgress?.bytes,
     }),
   };
 
@@ -1467,28 +1478,29 @@ export default function subagentsExtension(pi: ExtensionAPI) {
             sessionFile: running.sessionFile,
             launchScriptFile: running.launchScriptFile,
             status: "started",
-            statusCadenceSeconds: params.statusCadenceSeconds,
           },
         };
       },
 
       renderCall(args, theme) {
-        const agent = args.agent ? theme.fg("dim", ` (${args.agent})`) : "";
-        const cwdHint = args.cwd ? theme.fg("dim", ` in ${args.cwd}`) : "";
-        const cadenceHint = args.statusCadenceSeconds
-          ? theme.fg("dim", ` · idle window ${args.statusCadenceSeconds}s`)
+        const partialArgs = args as Record<string, unknown>;
+        const name = typeof partialArgs.name === "string" && partialArgs.name ? partialArgs.name : "(unnamed)";
+        const task = typeof partialArgs.task === "string" ? partialArgs.task : "";
+        const agent = typeof partialArgs.agent === "string" && partialArgs.agent
+          ? theme.fg("dim", ` (${partialArgs.agent})`)
+          : "";
+        const cwdHint = typeof partialArgs.cwd === "string" && partialArgs.cwd
+          ? theme.fg("dim", ` in ${partialArgs.cwd}`)
           : "";
         let text =
           "▸ " +
-          theme.fg("toolTitle", theme.bold(args.name ?? "(unnamed)")) +
+          theme.fg("toolTitle", theme.bold(name)) +
           agent +
-          cwdHint +
-          cadenceHint;
+          cwdHint;
 
         // Show a one-line task preview. renderCall is called repeatedly as the
         // LLM generates tool arguments, so args.task grows token by token.
         // We keep it compact here — Ctrl+O on renderResult expands the full content.
-        const task = args.task ?? "";
         if (task) {
           const firstLine = task.split("\n").find((l: string) => l.trim()) ?? "";
           const preview = firstLine.length > 100 ? firstLine.slice(0, 100) + "…" : firstLine;
@@ -1521,7 +1533,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         }
 
         // Fallback (shouldn't happen)
-        const text = typeof result.content?.[0]?.text === "string" ? result.content[0].text : "";
+        const text = typeof result.content[0]?.text === "string" ? result.content[0].text : "";
         return new Text(theme.fg("dim", text), 0, 0);
       },
     });
@@ -1573,7 +1585,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
           );
         }
 
-        const text = typeof result.content?.[0]?.text === "string" ? result.content[0].text : "";
+        const text = typeof result.content[0]?.text === "string" ? result.content[0].text : "";
         return new Text(theme.fg("dim", text), 0, 0);
       },
     });
@@ -1659,25 +1671,14 @@ export default function subagentsExtension(pi: ExtensionAPI) {
             description: "Optional message to send after resuming (e.g. follow-up instructions)",
           }),
         ),
-        statusCadenceSeconds: Type.Optional(
-          Type.Integer({
-            minimum: 1,
-            description:
-              "Optional per-run idle-time window in seconds for active/quiet/stalled classification in this resumed run. Lower values are clamped to a safe minimum.",
-          }),
-        ),
       }),
 
       renderCall(args, theme) {
         const name = args.name ?? "Resume";
-        const cadenceHint = args.statusCadenceSeconds
-          ? theme.fg("dim", ` · idle window ${args.statusCadenceSeconds}s`)
-          : "";
         const text =
           "▸ " +
           theme.fg("toolTitle", theme.bold(name)) +
-          theme.fg("dim", " — resuming session") +
-          cadenceHint;
+          theme.fg("dim", " — resuming session");
         return new Text(text, 0, 0);
       },
 
@@ -1697,13 +1698,14 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         }
 
         // Fallback
-        const text = typeof result.content?.[0]?.text === "string" ? result.content[0].text : "";
+        const text = typeof result.content[0]?.text === "string" ? result.content[0].text : "";
         return new Text(theme.fg("dim", text), 0, 0);
       },
 
       async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
         const name = params.name ?? "Resume";
         const startTime = Date.now();
+        const id = Math.random().toString(16).slice(2, 10);
 
         if (!isMuxAvailable()) {
           return muxUnavailableResult();
@@ -1723,7 +1725,6 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 
         const surface = createSurface(name);
         await new Promise<void>((resolve) => setTimeout(resolve, getShellReadyDelayMs()));
-        const statusCadenceMs = resolveStatusCadenceMs(statusConfig, params.statusCadenceSeconds);
 
         // Build pi resume command
         const parts = ["pi", "--session", shellEscape(params.sessionPath)];
@@ -1737,6 +1738,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 
         const sessionId = ctx.sessionManager.getSessionId();
         const artifactDir = getArtifactDir(ctx.sessionManager.getSessionDir(), sessionId);
+        const activityFile = getSubagentActivityFile(artifactDir, id);
+        mkdirSync(dirname(activityFile), { recursive: true });
 
         let resumeMsgFile: string | undefined;
         if (params.message) {
@@ -1761,7 +1764,11 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         if (process.env.PI_CODING_AGENT_DIR) {
           resumeEnvParts.push(`PI_CODING_AGENT_DIR=${shellEscape(process.env.PI_CODING_AGENT_DIR)}`);
         }
-        const resumeEnvPrefix = resumeEnvParts.length > 0 ? resumeEnvParts.join(" ") + " " : "";
+        resumeEnvParts.push(`PI_SUBAGENT_NAME=${shellEscape(name)}`);
+        resumeEnvParts.push(`PI_SUBAGENT_SESSION=${shellEscape(params.sessionPath)}`);
+        resumeEnvParts.push(`PI_SUBAGENT_ID=${shellEscape(id)}`);
+        resumeEnvParts.push(`PI_SUBAGENT_ACTIVITY_FILE=${shellEscape(activityFile)}`);
+        const resumeEnvPrefix = resumeEnvParts.join(" ") + " ";
 
         const command = `${resumeEnvPrefix}${parts.join(" ")}; echo '__SUBAGENT_DONE_'$?'__'`;
         const launchScriptFile = join(
@@ -1786,8 +1793,6 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         });
 
         // Register as a running subagent for widget tracking
-        const id = Math.random().toString(16).slice(2, 10);
-        const initialProgress = readSessionProgress(params.sessionPath);
         const running: RunningSubagent = {
           id,
           name,
@@ -1796,14 +1801,11 @@ export default function subagentsExtension(pi: ExtensionAPI) {
           startTime,
           sessionFile: params.sessionPath,
           launchScriptFile,
-          entries: initialProgress?.entries,
-          bytes: initialProgress?.bytes,
+          activityFile,
+          interactive: true,
           statusState: createStatusState({
             source: "pi",
             startTimeMs: startTime,
-            cadenceMs: statusCadenceMs,
-            baselineEntries: entryCountBefore,
-            baselineBytes: initialProgress?.bytes,
           }),
         };
         runningSubagents.set(id, running);
@@ -1883,7 +1885,6 @@ export default function subagentsExtension(pi: ExtensionAPI) {
             sessionPath: params.sessionPath,
             launchScriptFile,
             status: "started",
-            statusCadenceSeconds: params.statusCadenceSeconds,
           },
         };
       },
@@ -1893,7 +1894,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   pi.registerCommand("iterate", {
     description: "Fork session into a subagent for focused work (bugfixes, iteration)",
     handler: async (args, _ctx) => {
-      const task = args?.trim() || "";
+      const task = args.trim() || "";
       const toolCall = task
         ? `Use subagent to fork a session. fork: true, name: "Iterate", task: ${JSON.stringify(task)}`
         : `Use subagent to fork a session. fork: true, name: "Iterate", task: "The user wants to do some hands-on work. Help them with whatever they need."`;
@@ -1905,7 +1906,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   pi.registerCommand("subagent", {
     description: "Spawn a subagent: /subagent <agent> <task>",
     handler: async (args, ctx) => {
-      const trimmed = (args ?? "").trim();
+      const trimmed = args.trim();
       if (!trimmed) {
         ctx.ui.notify("Usage: /subagent <agent> [task]", "warning");
         return;
@@ -2068,7 +2069,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   pi.registerCommand("plan", {
     description: "Start a planning session: /plan <what to build>",
     handler: async (args, ctx) => {
-      const task = (args ?? "").trim();
+      const task = args.trim();
       if (!task) {
         ctx.ui.notify("Usage: /plan <what to build>", "warning");
         return;

--- a/pi-extension/subagents/session.ts
+++ b/pi-extension/subagents/session.ts
@@ -84,14 +84,6 @@ export function getLeafId(sessionFile: string): string | null {
 }
 
 /**
- * Return the number of non-empty lines (entries) in the session file.
- */
-export function getEntryCount(sessionFile: string): number {
-  const raw = readFileSync(sessionFile, "utf8");
-  return raw.split("\n").filter((line) => line.trim()).length;
-}
-
-/**
  * Return entries added after `afterLine` (1-indexed count of existing entries).
  */
 export function getNewEntries(sessionFile: string, afterLine: number): SessionEntry[] {

--- a/pi-extension/subagents/status.ts
+++ b/pi-extension/subagents/status.ts
@@ -2,10 +2,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export const DEFAULT_STATUS_CADENCE_MS = 60_000;
-export const MIN_STATUS_CADENCE_MS = 10_000;
-export const MIN_STALLED_MS = 30_000;
-export const STALLED_MULTIPLIER = 3;
+export const SNAPSHOT_STALLED_AFTER_MS = 60_000;
 export const DEFAULT_STATUS_LINE_LIMIT = 4;
 export const MAX_STATUS_NAME_LENGTH = 72;
 export const MAX_STATUS_LINE_LENGTH = 120;
@@ -14,35 +11,53 @@ const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
 const DEFAULT_STATUS_CONFIG_PATH = join(PACKAGE_ROOT, "config.json");
 const STATUS_CONFIG_EXAMPLE_PATH = join(PACKAGE_ROOT, "config.json.example");
 
-export type SubagentStatusKind = "starting" | "active" | "quiet" | "stalled" | "running";
+export type SubagentStatusKind = "starting" | "active" | "waiting" | "stalled" | "running";
 export type SubagentStatusSource = "pi" | "claude";
 export type SubagentStatusTransition = "stalled" | "recovered" | null;
+export type StatusSnapshotState = "unseen" | "present" | "missing" | "invalid" | "wrong-id";
+export type StatusActivityPhase = "starting" | "active" | "waiting" | "done";
 
 export interface StatusConfig {
   enabled: boolean;
-  defaultCadenceMs: number;
   lineLimit: number;
 }
 
-export interface StatusObservation {
-  entries: number;
-  bytes: number;
-}
+export type StatusObservation =
+  | {
+      snapshot: "present";
+      updatedAt: number;
+      sequence: number;
+      phase: StatusActivityPhase;
+      active?: boolean;
+      activeScope?: string;
+      activeSince?: number;
+      waitingSince?: number;
+      latestEvent?: string;
+      activityLabel?: string;
+    }
+  | {
+      snapshot: "missing" | "invalid" | "wrong-id";
+      snapshotError?: string;
+    };
 
 export interface SubagentStatusState {
   source: SubagentStatusSource;
   startTimeMs: number;
-  cadenceMs: number;
-  baselineEntries: number | null;
-  baselineBytes: number | null;
-  observedEntries: number | null;
-  observedBytes: number | null;
   firstObservationAtMs: number | null;
-  lastProgressAtMs: number | null;
-  // Cadence tracks classification/progress windows for local widget status.
-  // Routine status messages are intentionally not emitted.
-  lastCadenceAtMs: number;
-  lastCadenceEntries: number | null;
+  lastActivityAtMs: number | null;
+  lastActivitySequence: number | null;
+  localOverrideAtMs: number | null;
+  localOverrideSequence: number | null;
+  activeNow: boolean;
+  activeSinceMs: number | null;
+  activeScope: string | null;
+  waitingSinceMs: number | null;
+  phase: StatusActivityPhase | null;
+  latestEvent: string | null;
+  activityLabel: string | null;
+  snapshotState: StatusSnapshotState;
+  snapshotProblemSinceMs: number | null;
+  snapshotError: string | null;
   currentKind: SubagentStatusKind;
 }
 
@@ -50,9 +65,17 @@ export interface StatusSnapshot {
   kind: SubagentStatusKind;
   elapsedMs: number;
   elapsedText: string;
-  idleMs: number | null;
-  idleText: string | null;
-  progressEvents: number | null;
+  activeSinceMs: number | null;
+  activeDurationText: string | null;
+  activeScope: string | null;
+  waitingSinceMs: number | null;
+  waitingDurationText: string | null;
+  latestEvent: string | null;
+  activityLabel: string | null;
+  snapshotState: StatusSnapshotState;
+  snapshotError: string | null;
+  snapshotProblemText: string | null;
+  statusLabel: string | null;
 }
 
 export interface CappedStatusLines {
@@ -78,16 +101,16 @@ function requireBoolean(value: unknown, source: string, fieldName: string): bool
   return value;
 }
 
-function requirePositiveInteger(value: unknown, source: string, fieldName: string): number {
-  if (!Number.isInteger(value) || value <= 0) {
-    invalidStatusConfig(source, `${fieldName} must be a positive integer`);
+function rejectUnsupportedKeys(
+  value: Record<string, unknown>,
+  allowedKeys: string[],
+  source: string,
+  fieldName: string,
+): void {
+  const unsupportedKeys = Object.keys(value).filter((key) => !allowedKeys.includes(key));
+  if (unsupportedKeys.length > 0) {
+    invalidStatusConfig(source, `${fieldName} has unsupported key(s): ${unsupportedKeys.join(", ")}`);
   }
-  return value;
-}
-
-function clampCadenceMs(ms: number): number {
-  if (!Number.isFinite(ms) || ms <= 0) return DEFAULT_STATUS_CADENCE_MS;
-  return Math.max(MIN_STATUS_CADENCE_MS, Math.floor(ms));
 }
 
 function truncateText(text: string, maxLength: number): string {
@@ -105,19 +128,23 @@ function boundStatusLine(line: string): string {
   return truncateText(line.replace(/\s+/g, " ").trim(), MAX_STATUS_LINE_LENGTH);
 }
 
+function snapshotProblemLabel(snapshotState: StatusSnapshotState): string | null {
+  if (snapshotState === "wrong-id") return "wrong activity id";
+  return null;
+}
+
+function activityLabel(snapshot: Pick<StatusSnapshot, "activityLabel" | "activeScope">): string | null {
+  return snapshot.activityLabel ?? snapshot.activeScope;
+}
+
 export function parseStatusConfig(rawConfig: unknown, source = "config.json"): StatusConfig {
   const config = requireObject(rawConfig, source, "root");
   const status = requireObject(config.status, source, "status");
+  rejectUnsupportedKeys(status, ["enabled"], source, "status");
   const enabled = requireBoolean(status.enabled, source, "status.enabled");
-  const defaultCadenceSeconds = requirePositiveInteger(
-    status.defaultCadenceSeconds,
-    source,
-    "status.defaultCadenceSeconds",
-  );
 
   return {
     enabled,
-    defaultCadenceMs: clampCadenceMs(defaultCadenceSeconds * 1000),
     lineLimit: DEFAULT_STATUS_LINE_LIMIT,
   };
 }
@@ -160,18 +187,6 @@ export function loadStatusConfig(
   return parseStatusConfig(parsed, sourcePath);
 }
 
-export function resolveStatusCadenceMs(
-  config: StatusConfig,
-  requestedSeconds?: number,
-): number {
-  if (requestedSeconds == null) return config.defaultCadenceMs;
-  return clampCadenceMs(requestedSeconds * 1000);
-}
-
-export function getStalledAfterMs(cadenceMs: number): number {
-  return Math.max(cadenceMs * STALLED_MULTIPLIER, MIN_STALLED_MS);
-}
-
 export function formatElapsedDuration(ms: number): string {
   const totalSeconds = Math.max(0, Math.floor(ms / 1000));
   if (totalSeconds < 60) return `${totalSeconds}s`;
@@ -183,36 +198,29 @@ export function formatElapsedDuration(ms: number): string {
   return `${minutes}m`;
 }
 
-function isProgressIncrease(
-  previous: Pick<SubagentStatusState, "observedEntries" | "observedBytes">,
-  next: StatusObservation,
-): boolean {
-  if (previous.observedEntries == null || previous.observedBytes == null) {
-    return true;
-  }
-  return next.entries > previous.observedEntries || next.bytes > previous.observedBytes;
-}
-
 export function createStatusState(params: {
   source: SubagentStatusSource;
   startTimeMs: number;
-  cadenceMs: number;
-  baselineEntries?: number | null;
-  baselineBytes?: number | null;
 }): SubagentStatusState {
   const initialKind = params.source === "claude" ? "running" : "starting";
   return {
     source: params.source,
     startTimeMs: params.startTimeMs,
-    cadenceMs: params.cadenceMs,
-    baselineEntries: params.baselineEntries ?? null,
-    baselineBytes: params.baselineBytes ?? null,
-    observedEntries: params.baselineEntries ?? null,
-    observedBytes: params.baselineBytes ?? null,
-    firstObservationAtMs: params.baselineEntries != null ? params.startTimeMs : null,
-    lastProgressAtMs: null,
-    lastCadenceAtMs: params.startTimeMs,
-    lastCadenceEntries: params.baselineEntries ?? null,
+    firstObservationAtMs: null,
+    lastActivityAtMs: null,
+    lastActivitySequence: null,
+    localOverrideAtMs: null,
+    localOverrideSequence: null,
+    activeNow: false,
+    activeSinceMs: null,
+    activeScope: null,
+    waitingSinceMs: null,
+    phase: null,
+    latestEvent: null,
+    activityLabel: null,
+    snapshotState: params.source === "claude" ? "unseen" : "unseen",
+    snapshotProblemSinceMs: null,
+    snapshotError: null,
     currentKind: initialKind,
   };
 }
@@ -222,41 +230,110 @@ export function observeStatus(
   observation: StatusObservation,
   now: number,
 ): SubagentStatusState {
-  const progressIncrease = isProgressIncrease(state, observation);
-  const baselineEntries = state.baselineEntries ?? 0;
-  const baselineBytes = state.baselineBytes ?? 0;
-  const crossesBaseline = observation.entries > baselineEntries || observation.bytes > baselineBytes;
-  const shouldMarkProgress = progressIncrease && crossesBaseline;
+  if (state.source === "claude") return state;
+
+  if (observation.snapshot !== "present") {
+    return {
+      ...state,
+      firstObservationAtMs: state.firstObservationAtMs ?? now,
+      snapshotState: observation.snapshot,
+      snapshotProblemSinceMs: state.snapshotProblemSinceMs ?? now,
+      snapshotError: observation.snapshotError ?? null,
+    };
+  }
+
+  const updatedAt = observation.updatedAt;
+  const sequence = observation.sequence;
+  const lastActivityAtMs = state.lastActivityAtMs;
+  const lastActivitySequence = state.lastActivitySequence;
+  const olderThanLastActivity = lastActivityAtMs != null && (
+    updatedAt < lastActivityAtMs ||
+    (updatedAt === lastActivityAtMs && lastActivitySequence != null && sequence < lastActivitySequence)
+  );
+  if (olderThanLastActivity) return state;
+
+  const blockedByLocalOverride = state.localOverrideAtMs != null && (
+    updatedAt < state.localOverrideAtMs ||
+    (updatedAt === state.localOverrideAtMs && state.localOverrideSequence != null && sequence <= state.localOverrideSequence)
+  );
+  if (blockedByLocalOverride) return state;
+
+  const phase = observation.phase;
+  const activeNow = phase === "active" || observation.active === true;
+  const activeSinceMs = activeNow
+    ? observation.activeSince ?? state.activeSinceMs ?? updatedAt
+    : null;
+  const waitingSinceMs = phase === "waiting"
+    ? observation.waitingSince ?? state.waitingSinceMs ?? updatedAt
+    : null;
 
   return {
     ...state,
-    observedEntries: observation.entries,
-    observedBytes: observation.bytes,
     firstObservationAtMs: state.firstObservationAtMs ?? now,
-    lastProgressAtMs: shouldMarkProgress ? now : state.lastProgressAtMs,
+    lastActivityAtMs: updatedAt,
+    lastActivitySequence: sequence,
+    activeNow,
+    activeSinceMs,
+    activeScope: activeNow ? observation.activeScope ?? null : null,
+    waitingSinceMs,
+    phase,
+    latestEvent: observation.latestEvent ?? null,
+    activityLabel: observation.activityLabel ?? null,
+    snapshotState: "present",
+    snapshotProblemSinceMs: null,
+    snapshotError: null,
+    localOverrideAtMs: null,
+    localOverrideSequence: null,
   };
 }
 
-export function forceStatusQuiet(state: SubagentStatusState, now: number): SubagentStatusState {
-  // The interrupt path currently applies only to Pi-backed children.
-  // Claude-backed states always classify as `running`, so accidental calls stay a no-op.
+export function forceStatusAfterInterrupt(state: SubagentStatusState, now: number): SubagentStatusState {
   if (state.source === "claude") return state;
-
-  const quietIdleMs = state.cadenceMs + 1;
-  const maxQuietIdleMs = getStalledAfterMs(state.cadenceMs) - 1;
-  const forcedIdleMs = Math.min(quietIdleMs, maxQuietIdleMs);
-  const forcedProgressAtMs = now - forcedIdleMs;
-  const firstObservationAtMs =
-    state.firstObservationAtMs == null || state.firstObservationAtMs > forcedProgressAtMs
-      ? forcedProgressAtMs
-      : state.firstObservationAtMs;
 
   return {
     ...state,
-    firstObservationAtMs,
-    lastProgressAtMs: forcedProgressAtMs,
-    currentKind: "quiet",
+    firstObservationAtMs: state.firstObservationAtMs ?? now,
+    lastActivityAtMs: now,
+    localOverrideAtMs: now,
+    localOverrideSequence: state.lastActivitySequence,
+    activeNow: false,
+    activeSinceMs: null,
+    activeScope: null,
+    waitingSinceMs: now,
+    phase: "waiting",
+    latestEvent: "interrupt_requested",
+    activityLabel: "interrupted",
+    snapshotState: "present",
+    snapshotProblemSinceMs: null,
+    snapshotError: null,
+    currentKind: "waiting",
   };
+}
+
+function classifyProblemState(state: SubagentStatusState, now: number): Pick<StatusSnapshot, "kind" | "statusLabel"> {
+  const problemLabel = snapshotProblemLabel(state.snapshotState);
+  const hasValidSnapshot = state.lastActivityAtMs != null;
+
+  if (!hasValidSnapshot) {
+    const referenceMs = state.firstObservationAtMs ?? state.startTimeMs;
+    const elapsedMs = Math.max(0, now - referenceMs);
+    return elapsedMs >= SNAPSHOT_STALLED_AFTER_MS
+      ? { kind: "stalled", statusLabel: problemLabel }
+      : { kind: "starting", statusLabel: null };
+  }
+
+  const problemSinceMs = state.snapshotProblemSinceMs ?? now;
+  const problemMs = Math.max(0, now - problemSinceMs);
+  if (problemMs >= SNAPSHOT_STALLED_AFTER_MS) return { kind: "stalled", statusLabel: problemLabel };
+
+  const lastHealthyKind = state.activeNow
+    ? "active"
+    : state.waitingSinceMs != null || state.phase === "done"
+      ? "waiting"
+      : state.currentKind === "stalled"
+        ? "starting"
+        : state.currentKind;
+  return { kind: lastHealthyKind, statusLabel: problemLabel };
 }
 
 export function classifyStatus(state: SubagentStatusState, now: number): StatusSnapshot {
@@ -268,46 +345,68 @@ export function classifyStatus(state: SubagentStatusState, now: number): StatusS
       kind: "running",
       elapsedMs,
       elapsedText,
-      idleMs: null,
-      idleText: null,
-      progressEvents: null,
+      activeSinceMs: null,
+      activeDurationText: null,
+      activeScope: null,
+      waitingSinceMs: null,
+      waitingDurationText: null,
+      latestEvent: null,
+      activityLabel: null,
+      snapshotState: state.snapshotState,
+      snapshotError: null,
+      snapshotProblemText: null,
+      statusLabel: null,
     };
   }
 
-  if (state.observedEntries == null || state.observedBytes == null) {
-    const idleStartMs = state.lastProgressAtMs ?? state.firstObservationAtMs ?? state.startTimeMs;
-    const idleMs = Math.max(0, now - idleStartMs);
-    const stalled = idleMs >= getStalledAfterMs(state.cadenceMs);
-    const hasLocalQuietMarker = state.lastProgressAtMs != null;
-    return {
-      kind: stalled ? "stalled" : hasLocalQuietMarker ? "quiet" : "starting",
-      elapsedMs,
-      elapsedText,
-      idleMs,
-      idleText: formatElapsedDuration(idleMs),
-      progressEvents: null,
-    };
+  let kind: SubagentStatusKind;
+  let statusLabel: string | null = null;
+
+  if (state.snapshotState === "present") {
+    if (state.phase === "active" || state.activeNow) {
+      kind = "active";
+    } else if (state.phase === "waiting") {
+      kind = "waiting";
+    } else if (state.phase === "done") {
+      kind = "waiting";
+      statusLabel = "done";
+    } else {
+      const referenceMs = state.firstObservationAtMs ?? state.startTimeMs;
+      const elapsedSinceObservationMs = Math.max(0, now - referenceMs);
+      kind = elapsedSinceObservationMs >= SNAPSHOT_STALLED_AFTER_MS ? "stalled" : "starting";
+      statusLabel = null;
+    }
+  } else {
+    const classified = classifyProblemState(state, now);
+    kind = classified.kind;
+    statusLabel = classified.statusLabel;
   }
 
-  const idleStartMs = state.lastProgressAtMs ?? state.firstObservationAtMs ?? state.startTimeMs;
-  const idleMs = Math.max(0, now - idleStartMs);
-  const kind = idleMs >= getStalledAfterMs(state.cadenceMs)
-    ? "stalled"
-    : state.lastProgressAtMs != null && idleMs < state.cadenceMs
-      ? "active"
-      : "quiet";
-  const progressEvents =
-    state.observedEntries != null && state.lastCadenceEntries != null
-      ? Math.max(0, state.observedEntries - state.lastCadenceEntries)
-      : null;
+  const activeDurationText = state.activeSinceMs == null
+    ? null
+    : formatElapsedDuration(now - state.activeSinceMs);
+  const waitingDurationText = state.waitingSinceMs == null
+    ? null
+    : formatElapsedDuration(now - state.waitingSinceMs);
+  const snapshotProblemText = state.snapshotProblemSinceMs == null
+    ? null
+    : formatElapsedDuration(now - state.snapshotProblemSinceMs);
 
   return {
     kind,
     elapsedMs,
     elapsedText,
-    idleMs,
-    idleText: formatElapsedDuration(idleMs),
-    progressEvents,
+    activeSinceMs: state.activeSinceMs,
+    activeDurationText,
+    activeScope: state.activeScope,
+    waitingSinceMs: state.waitingSinceMs,
+    waitingDurationText,
+    latestEvent: state.latestEvent,
+    activityLabel: state.activityLabel,
+    snapshotState: state.snapshotState,
+    snapshotError: state.snapshotError,
+    snapshotProblemText,
+    statusLabel,
   };
 }
 
@@ -318,35 +417,49 @@ export function advanceStatusState(
   nextState: SubagentStatusState;
   snapshot: StatusSnapshot;
   transition: SubagentStatusTransition;
-  cadenceElapsed: boolean;
 } {
   const snapshot = classifyStatus(state, now);
   const transition =
     state.currentKind !== "stalled" && snapshot.kind === "stalled"
       ? "stalled"
-      : state.currentKind === "stalled" && snapshot.kind === "active"
+      : state.currentKind === "stalled" && (snapshot.kind === "active" || snapshot.kind === "waiting")
         ? "recovered"
         : null;
-  const cadenceElapsed = now - state.lastCadenceAtMs >= state.cadenceMs;
 
   return {
     snapshot,
     transition,
-    cadenceElapsed,
     nextState: {
       ...state,
       currentKind: snapshot.kind,
-      lastCadenceAtMs: cadenceElapsed ? now : state.lastCadenceAtMs,
-      lastCadenceEntries: cadenceElapsed ? state.observedEntries : state.lastCadenceEntries,
     },
   };
+}
+
+function formatActiveDetail(snapshot: StatusSnapshot): string {
+  const label = activityLabel(snapshot);
+  if (!label) return "active";
+  const duration = snapshot.activeDurationText ? ` ${snapshot.activeDurationText}` : "";
+  return `active (${label}${duration})`;
+}
+
+function formatWaitingDetail(snapshot: StatusSnapshot): string {
+  const duration = snapshot.waitingDurationText ? ` ${snapshot.waitingDurationText}` : "";
+  return `waiting${duration}`;
+}
+
+function formatStalledDetail(snapshot: StatusSnapshot): string {
+  const detail = snapshot.statusLabel ? ` (${snapshot.statusLabel})` : "";
+  const duration = snapshot.snapshotProblemText ? ` ${snapshot.snapshotProblemText}` : "";
+  return `stalled${duration}${detail}`;
 }
 
 export function formatStatusLine(name: string, snapshot: StatusSnapshot): string {
   const boundedName = normalizeStatusName(name);
 
   if (snapshot.kind === "starting") {
-    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, starting.`);
+    const label = snapshot.statusLabel ? ` (${snapshot.statusLabel})` : "";
+    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, starting${label}.`);
   }
 
   if (snapshot.kind === "running") {
@@ -354,15 +467,19 @@ export function formatStatusLine(name: string, snapshot: StatusSnapshot): string
   }
 
   if (snapshot.kind === "active") {
-    const progress = snapshot.progressEvents && snapshot.progressEvents > 0
-      ? ` (+${snapshot.progressEvents} events)`
-      : "";
-    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, active${progress}.`);
+    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, ${formatActiveDetail(snapshot)}.`);
   }
 
-  return boundStatusLine(
-    `${boundedName} running ${snapshot.elapsedText}, ${snapshot.kind} ${snapshot.idleText}.`,
-  );
+  if (snapshot.kind === "waiting") {
+    const problem = snapshot.statusLabel && snapshot.statusLabel !== "done"
+      ? ` (${snapshot.statusLabel})`
+      : snapshot.statusLabel === "done"
+        ? " (done)"
+        : "";
+    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, ${formatWaitingDetail(snapshot)}${problem}.`);
+  }
+
+  return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, ${formatStalledDetail(snapshot)}.`);
 }
 
 export function formatTransitionLine(
@@ -373,10 +490,8 @@ export function formatTransitionLine(
   const boundedName = normalizeStatusName(name);
 
   if (transition === "recovered") {
-    const progress = snapshot.progressEvents && snapshot.progressEvents > 0
-      ? ` (+${snapshot.progressEvents} events)`
-      : "";
-    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, recovered; active${progress}.`);
+    const detail = snapshot.kind === "waiting" ? formatWaitingDetail(snapshot) : formatActiveDetail(snapshot);
+    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, recovered; ${detail}.`);
   }
 
   return formatStatusLine(boundedName, snapshot);

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -7,6 +7,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Box, Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { writeFileSync } from "node:fs";
+import { createSubagentActivityRecorder } from "./activity.ts";
 
 export function shouldMarkUserTookOver(agentStarted: boolean): boolean {
   return agentStarted;
@@ -46,6 +47,11 @@ export default function (pi: ExtensionAPI) {
   const subagentName = process.env.PI_SUBAGENT_NAME ?? "";
   const subagentAgent = process.env.PI_SUBAGENT_AGENT ?? "";
   const deniedToolsValue = process.env.PI_DENY_TOOLS;
+  const autoExit = process.env.PI_SUBAGENT_AUTO_EXIT === "1";
+  const recorder = createSubagentActivityRecorder({
+    runningChildId: process.env.PI_SUBAGENT_ID,
+    activityFile: process.env.PI_SUBAGENT_ACTIVITY_FILE,
+  });
 
   function renderWidget(ctx: { ui: { setWidget: Function } }, _theme: any) {
     ctx.ui.setWidget(
@@ -98,10 +104,12 @@ export default function (pi: ExtensionAPI) {
     );
   }
 
-  const autoExit = process.env.PI_SUBAGENT_AUTO_EXIT === "1";
+  let userTookOver = false;
+  let agentStarted = false;
 
   // Show widget + status bar on session start
   pi.on("session_start", (_event, ctx) => {
+    recorder.sessionStart();
     const tools = pi.getAllTools();
     toolNames = tools.map((t) => t.name).sort();
     denied = parseDeniedTools(deniedToolsValue);
@@ -109,40 +117,85 @@ export default function (pi: ExtensionAPI) {
     renderWidget(ctx, null);
   });
 
-  // Auto-exit: when the agent loop ends, shut down automatically.
-  // If the user interrupts (Escape) or sends any input, auto-exit is disabled
-  // for that cycle — the user wants to steer. Once they're done and the agent
-  // completes normally again, auto-exit re-engages.
-  // Enabled via `auto-exit: true` in agent frontmatter.
-  if (autoExit) {
-    let userTookOver = false;
-    let agentStarted = false;
+  pi.on("input", () => {
+    recorder.input();
+    // Ignore the initial task message that starts an autonomous subagent.
+    // Only inputs after the first agent run has started count as user takeover.
+    if (!shouldMarkUserTookOver(agentStarted)) return;
+    userTookOver = true;
+  });
 
-    pi.on("agent_start", () => {
-      agentStarted = true;
-    });
+  pi.on("before_agent_start", () => {
+    recorder.beforeAgentStart();
+  });
 
-    pi.on("input", () => {
-      // Ignore the initial task message that starts an autonomous subagent.
-      // Only inputs after the first agent run has started count as user takeover.
-      if (!shouldMarkUserTookOver(agentStarted)) return;
-      userTookOver = true;
-    });
+  pi.on("agent_start", () => {
+    agentStarted = true;
+    recorder.agentStart();
+  });
 
-    pi.on("agent_end", (event, ctx) => {
-      const messages = (event as any).messages as any[] | undefined;
-      const shouldExit = shouldAutoExitOnAgentEnd(userTookOver, messages);
-      if (!shouldExit) {
-        // User sent input after the agent had started, or the run was interrupted
-        // with Escape. Reset takeover so auto-exit can re-engage on the next
-        // normal completion cycle.
-        userTookOver = false;
-        return;
-      }
+  pi.on("agent_end", (event, ctx) => {
+    const messages = (event as any).messages as any[] | undefined;
+    const shouldExit = autoExit && shouldAutoExitOnAgentEnd(userTookOver, messages);
 
+    if (shouldExit) {
+      recorder.agentEndDone();
       ctx.shutdown();
-    });
-  }
+      return;
+    }
+
+    recorder.agentEndWaiting();
+    if (autoExit) {
+      // User sent input after the agent had started, or the run was interrupted
+      // with Escape. Reset takeover so auto-exit can re-engage on the next
+      // normal completion cycle.
+      userTookOver = false;
+    }
+  });
+
+  pi.on("turn_start", (event) => {
+    recorder.turnStart((event as any).turnIndex);
+  });
+
+  pi.on("turn_end", (event) => {
+    recorder.turnEnd((event as any).turnIndex);
+  });
+
+  pi.on("before_provider_request", () => {
+    recorder.beforeProviderRequest();
+  });
+
+  pi.on("after_provider_response", () => {
+    recorder.afterProviderResponse();
+  });
+
+  pi.on("message_update", (event) => {
+    recorder.messageUpdate((event as any).assistantMessageEvent?.type);
+  });
+
+  pi.on("tool_execution_start", (event) => {
+    recorder.toolExecutionStart((event as any).toolCallId, (event as any).toolName);
+  });
+
+  pi.on("tool_call", (event) => {
+    recorder.toolCall((event as any).toolCallId, (event as any).toolName);
+  });
+
+  pi.on("tool_execution_update", (event) => {
+    recorder.toolExecutionUpdate((event as any).toolCallId, (event as any).toolName);
+  });
+
+  pi.on("tool_result", (event) => {
+    recorder.toolResult((event as any).toolCallId, (event as any).toolName);
+  });
+
+  pi.on("tool_execution_end", (event) => {
+    recorder.toolExecutionEnd((event as any).toolCallId, (event as any).toolName);
+  });
+
+  pi.on("session_shutdown", (event) => {
+    recorder.sessionShutdown((event as any).reason);
+  });
 
   // Toggle expand/collapse with Ctrl+J
   pi.registerShortcut("ctrl+j", {
@@ -172,6 +225,7 @@ export default function (pi: ExtensionAPI) {
         );
       }
 
+      recorder.callerPing();
       const exitData = {
         type: "ping" as const,
         name: process.env.PI_SUBAGENT_NAME ?? "subagent",
@@ -197,6 +251,7 @@ export default function (pi: ExtensionAPI) {
     parameters: Type.Object({}),
     async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
       const sessionFile = process.env.PI_SUBAGENT_SESSION;
+      recorder.subagentDone();
       if (sessionFile) {
         writeFileSync(`${sessionFile}.exit`, JSON.stringify({ type: "done" }));
       }

--- a/test/integration/subagent-lifecycle.test.ts
+++ b/test/integration/subagent-lifecycle.test.ts
@@ -109,11 +109,13 @@ for (const backend of backends) {
       }
     });
 
-    // ── In-progress stalled status ──
+    // ── In-progress activity snapshots ──
 
-    it("surfaces a compact stalled status before final completion", async () => {
+    it("keeps a long active tool call from surfacing false stalled status", async () => {
       const id = uniqueId();
+      const startFile = `/tmp/pi-integ-status-start-${id}.txt`;
       const markerFile = `/tmp/pi-integ-status-${id}.txt`;
+      trackTempFile(env, startFile);
       trackTempFile(env, markerFile);
 
       const surface = createTrackedSurface(env, `status-${id}`);
@@ -123,22 +125,22 @@ for (const backend of backends) {
         `Call the subagent tool with these EXACT parameters:`,
         `  name: "Status-${id}"`,
         `  agent: "test-echo"`,
-        `  statusCadenceSeconds: 10`,
-        `  task: "Run this bash command: sleep 55; echo 'STATUS_${id}' > '${markerFile}'"`,
+        `  task: "Run this bash command: echo 'START_${id}' > '${startFile}'; sleep 90; echo 'STATUS_${id}' > '${markerFile}'"`,
         `Do not do anything else. Just call the subagent tool once.`,
         `After you receive the subagent result, say STATUS_TEST_DONE.`,
       ].join("\n");
 
       startPi(surface, env.dir, task);
 
-      const stalledScreen = await waitForScreen(
-        surface,
-        /Subagent status[\s\S]*stalled|stalled[\s\S]*Subagent status/i,
-        PI_TIMEOUT,
-        300,
-      );
-      assert.match(stalledScreen, /Subagent status/i);
-      assert.match(stalledScreen, /stalled/i);
+      const activeScreen = await waitForScreen(surface, /active[\s\S]*bash|bash[\s\S]*active/i, PI_TIMEOUT, 300);
+      assert.doesNotMatch(activeScreen, /Subagent status[\s\S]*stalled|stalled[\s\S]*Subagent status/i);
+
+      await waitForFile(startFile, PI_TIMEOUT, /START_/);
+      assert.equal(existsSync(markerFile), false, "Completion marker should not exist before the long sleep");
+      await sleep(65_000);
+      assert.equal(existsSync(markerFile), false, "Completion marker should not exist before the watchdog assertion");
+      const watchdogScreen = readScreen(surface, 300);
+      assert.doesNotMatch(watchdogScreen, /Subagent status[\s\S]*stalled|stalled[\s\S]*Subagent status/i);
 
       const content = await waitForFile(markerFile, PI_TIMEOUT, /STATUS_/);
       assert.ok(content.includes(`STATUS_${id}`), `Marker file should contain STATUS_${id}`);

--- a/test/test.ts
+++ b/test/test.ts
@@ -9,7 +9,6 @@ import * as subagentsModule from "../pi-extension/subagents/index.ts";
 
 import {
   getLeafId,
-  getEntryCount,
   getNewEntries,
   findLastAssistantMessage,
   appendBranchSummary,
@@ -24,16 +23,19 @@ import {
   capStatusLines,
   classifyStatus,
   createStatusState,
-  forceStatusQuiet,
+  forceStatusAfterInterrupt,
   formatStatusAggregate,
-  getStalledAfterMs,
   formatStatusLine,
   formatTransitionLine,
   observeStatus,
   loadStatusConfig,
   parseStatusConfig,
-  resolveStatusCadenceMs,
 } from "../pi-extension/subagents/status.ts";
+import {
+  createSubagentActivityRecorder,
+  getSubagentActivityFile,
+  readSubagentActivityFile,
+} from "../pi-extension/subagents/activity.ts";
 import {
   shouldMarkUserTookOver,
   shouldAutoExitOnAgentEnd,
@@ -225,19 +227,6 @@ describe("session.ts", () => {
     });
   });
 
-  describe("getEntryCount", () => {
-    it("counts non-empty lines", () => {
-      const file = createSessionFile(dir, [SESSION_HEADER, MODEL_CHANGE, USER_MSG]);
-      assert.equal(getEntryCount(file), 3);
-    });
-
-    it("returns 0 for empty file", () => {
-      const file = join(dir, "empty2.jsonl");
-      writeFileSync(file, "\n\n");
-      assert.equal(getEntryCount(file), 0);
-    });
-  });
-
   describe("getNewEntries", () => {
     it("returns entries after a given line", () => {
       const file = createSessionFile(dir, [SESSION_HEADER, MODEL_CHANGE, USER_MSG, ASSISTANT_MSG]);
@@ -419,17 +408,13 @@ describe("session.ts", () => {
 });
 
 describe("status.ts", () => {
-  it("parses strict config objects and clamps cadence bounds", () => {
-    const disabled = parseStatusConfig({
-      status: {
-        enabled: false,
-        defaultCadenceSeconds: 5,
-      },
-    });
+  it("parses strict config objects", () => {
+    const disabled = parseStatusConfig({ status: { enabled: false } });
 
-    assert.equal(disabled.enabled, false);
-    assert.equal(disabled.defaultCadenceMs, 10_000);
-    assert.equal(resolveStatusCadenceMs(disabled, 10), 10_000);
+    assert.deepEqual(disabled, {
+      enabled: false,
+      lineLimit: 4,
+    });
   });
 
   it("loads a valid config file", () => {
@@ -438,7 +423,6 @@ describe("status.ts", () => {
 
     assert.deepEqual(config, {
       enabled: true,
-      defaultCadenceMs: 60_000,
       lineLimit: 4,
     });
   });
@@ -448,14 +432,13 @@ describe("status.ts", () => {
       const examplePath = join(dir, "config.json.example");
       writeFileSync(
         examplePath,
-        JSON.stringify({ status: { enabled: true, defaultCadenceSeconds: 45 } }, null, 2) + "\n",
+        JSON.stringify({ status: { enabled: true } }, null, 2) + "\n",
       );
 
       const config = loadStatusConfig(join(dir, "config.json"), examplePath);
 
       assert.deepEqual(config, {
         enabled: true,
-        defaultCadenceMs: 45_000,
         lineLimit: 4,
       });
     });
@@ -463,12 +446,12 @@ describe("status.ts", () => {
 
   it("fails fast for invalid config shapes", () => {
     assert.throws(
-      () => parseStatusConfig({ status: { enabled: "false", defaultCadenceSeconds: 60 } }),
+      () => parseStatusConfig({ status: { enabled: "false" } }),
       /status\.enabled must be a boolean/,
     );
     assert.throws(
-      () => parseStatusConfig({ status: { enabled: true } }),
-      /status\.defaultCadenceSeconds must be a positive integer/,
+      () => parseStatusConfig({ status: { enabled: true, defaultCadenceSeconds: 60 } }),
+      /status has unsupported key\(s\): defaultCadenceSeconds/,
     );
   });
 
@@ -500,7 +483,7 @@ describe("status.ts", () => {
       writeFileSync(configPath, "{\n");
       writeFileSync(
         examplePath,
-        JSON.stringify({ status: { enabled: true, defaultCadenceSeconds: 45 } }, null, 2) + "\n",
+        JSON.stringify({ status: { enabled: true } }, null, 2) + "\n",
       );
 
       assert.throws(
@@ -510,41 +493,54 @@ describe("status.ts", () => {
     });
   });
 
-  it("keeps no-observation runs as starting, then marks them stalled", () => {
-    const state = createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 });
+  it("keeps a missing snapshot as starting until the fixed watchdog threshold", () => {
+    let state = createStatusState({ source: "pi", startTimeMs: 0 });
+    state = observeStatus(state, { snapshot: "missing" }, 1_000);
 
-    assert.equal(classifyStatus(state, 10_000).kind, "starting");
-    assert.equal(classifyStatus(state, 95_000).kind, "stalled");
-    assert.equal(classifyStatus(state, 95_000).idleText, "1m");
+    assert.equal(classifyStatus(state, 60_999).kind, "starting");
+    const stalled = classifyStatus(state, 61_000);
+    assert.equal(stalled.kind, "stalled");
+    assert.equal(stalled.statusLabel, null);
   });
 
-  it("does not treat inherited baseline entries as fresh progress", () => {
-    let state = createStatusState({
-      source: "pi",
-      startTimeMs: 0,
-      cadenceMs: 60_000,
-      baselineEntries: 3,
-      baselineBytes: 300,
-    });
+  it("classifies active snapshots without aging into stalled", () => {
+    let state = createStatusState({ source: "pi", startTimeMs: 0 });
+    state = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 5_000,
+      sequence: 1,
+      phase: "active",
+      active: true,
+      activeScope: "tool",
+      activeSince: 5_000,
+      activityLabel: "bash",
+      latestEvent: "tool_execution_start",
+    }, 5_000);
 
-    state = observeStatus(state, { entries: 3, bytes: 300 }, 1_000);
-    const snapshot = classifyStatus(state, 30_000);
-
-    assert.equal(snapshot.kind, "quiet");
-    assert.equal(snapshot.progressEvents, 0);
+    const snapshot = classifyStatus(state, 240_000);
+    assert.equal(snapshot.kind, "active");
+    assert.equal(snapshot.activityLabel, "bash");
+    assert.equal(snapshot.activeDurationText, "3m");
   });
 
-  it("classifies active then quiet then stalled based on elapsed inactivity", () => {
-    let state = createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 });
-    state = observeStatus(state, { entries: 1, bytes: 100 }, 5_000);
+  it("classifies waiting snapshots as healthy idle without becoming stalled", () => {
+    let state = createStatusState({ source: "pi", startTimeMs: 0 });
+    state = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 10_000,
+      sequence: 1,
+      phase: "waiting",
+      waitingSince: 10_000,
+      latestEvent: "agent_end",
+    }, 10_000);
 
-    assert.equal(classifyStatus(state, 10_000).kind, "active");
-    assert.equal(classifyStatus(state, 40_000).kind, "quiet");
-    assert.equal(classifyStatus(state, 95_000).kind, "stalled");
+    const snapshot = classifyStatus(state, 240_000);
+    assert.equal(snapshot.kind, "waiting");
+    assert.equal(snapshot.waitingDurationText, "3m");
   });
 
   it("uses elapsed-only fallback for claude-backed subagents", () => {
-    const state = createStatusState({ source: "claude", startTimeMs: 0, cadenceMs: 30_000 });
+    const state = createStatusState({ source: "claude", startTimeMs: 0 });
     const snapshot = classifyStatus(state, 125_000);
 
     assert.equal(snapshot.kind, "running");
@@ -552,112 +548,208 @@ describe("status.ts", () => {
   });
 
   it("detects stalled transitions and recovery", () => {
-    let state = createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 });
-    state = observeStatus(state, { entries: 1, bytes: 100 }, 5_000);
+    let state = createStatusState({ source: "pi", startTimeMs: 0 });
+    state = observeStatus(state, { snapshot: "missing" }, 1_000);
 
     let advanced = advanceStatusState(state, 95_000);
     assert.equal(advanced.transition, "stalled");
     assert.equal(advanced.snapshot.kind, "stalled");
 
-    state = observeStatus(advanced.nextState, { entries: 2, bytes: 200 }, 96_000);
+    state = observeStatus(advanced.nextState, {
+      snapshot: "present",
+      updatedAt: 96_000,
+      sequence: 1,
+      phase: "waiting",
+      waitingSince: 96_000,
+      latestEvent: "agent_end",
+    }, 96_000);
     advanced = advanceStatusState(state, 97_000);
     assert.equal(advanced.transition, "recovered");
-    assert.equal(advanced.snapshot.kind, "active");
+    assert.equal(advanced.snapshot.kind, "waiting");
   });
 
-  it("forces an active state to quiet without discarding observed progress", () => {
+  it("keeps the last healthy kind during transient snapshot loss", () => {
+    let state = createStatusState({ source: "pi", startTimeMs: 0 });
+    state = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 5_000,
+      sequence: 1,
+      phase: "active",
+      active: true,
+      activeScope: "streaming",
+      activeSince: 5_000,
+    }, 5_000);
+    state = advanceStatusState(state, 6_000).nextState;
+    state = observeStatus(state, { snapshot: "missing" }, 10_000);
+
+    const snapshot = classifyStatus(state, 20_000);
+    assert.equal(snapshot.kind, "active");
+    assert.equal(snapshot.statusLabel, null);
+  });
+
+  it("forces an active state to waiting after interrupt", () => {
     const now = 20_000;
-    let state = createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 });
-    state = observeStatus(state, { entries: 2, bytes: 200 }, 5_000);
+    let state = createStatusState({ source: "pi", startTimeMs: 0 });
+    state = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 5_000,
+      sequence: 1,
+      phase: "active",
+      active: true,
+      activeScope: "tool",
+      activeSince: 5_000,
+      activityLabel: "bash",
+    }, 5_000);
 
     assert.equal(classifyStatus(state, now).kind, "active");
 
-    const forced = forceStatusQuiet(state, now);
+    const forced = forceStatusAfterInterrupt(state, now);
     const snapshot = classifyStatus(forced, now);
 
-    assert.equal(snapshot.kind, "quiet");
-    assert.equal(forced.observedEntries, state.observedEntries);
-    assert.equal(forced.observedBytes, state.observedBytes);
-    assert.ok(snapshot.idleMs != null);
-    assert.ok(snapshot.idleMs >= forced.cadenceMs);
-    assert.ok(snapshot.idleMs < getStalledAfterMs(forced.cadenceMs));
+    assert.equal(snapshot.kind, "waiting");
+    assert.equal(snapshot.activityLabel, "interrupted");
+    assert.equal(snapshot.waitingDurationText, "0s");
+    assert.equal(forced.activeNow, false);
   });
 
-  it("forces a no-observation state to quiet for local bookkeeping", () => {
-    const now = 20_000;
-    const state = createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 });
+  it("orders same-millisecond snapshots by sequence", () => {
+    let state = createStatusState({ source: "pi", startTimeMs: 0 });
+    state = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 10_000,
+      sequence: 2,
+      phase: "active",
+      active: true,
+      activeScope: "tool",
+      activeSince: 10_000,
+      activityLabel: "bash",
+    }, 10_000);
 
-    const forced = forceStatusQuiet(state, now);
+    state = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 10_000,
+      sequence: 3,
+      phase: "waiting",
+      waitingSince: 10_000,
+      latestEvent: "agent_end",
+    }, 10_001);
 
-    assert.equal(classifyStatus(forced, now).kind, "quiet");
-    assert.equal(forced.observedEntries, null);
-    assert.equal(forced.observedBytes, null);
+    const snapshot = classifyStatus(state, 11_000);
+    assert.equal(snapshot.kind, "waiting");
+    assert.equal(snapshot.latestEvent, "agent_end");
   });
 
-  it("lets a forced-quiet state become stalled under the existing timeout", () => {
-    const now = 20_000;
-    let state = createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 });
-    state = observeStatus(state, { entries: 2, bytes: 200 }, 5_000);
+  it("recovers from a transient snapshot read failure with the same valid snapshot", () => {
+    let state = createStatusState({ source: "pi", startTimeMs: 0 });
+    state = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 5_000,
+      sequence: 2,
+      phase: "active",
+      active: true,
+      activeScope: "tool",
+      activeSince: 5_000,
+      activityLabel: "bash",
+    }, 5_000);
+    state = observeStatus(state, { snapshot: "missing" }, 10_000);
+    assert.equal(classifyStatus(state, 10_000).statusLabel, null);
 
-    const forced = forceStatusQuiet(state, now);
-    const forcedSnapshot = classifyStatus(forced, now);
-    const stalledAt = now + (getStalledAfterMs(forced.cadenceMs) - (forcedSnapshot.idleMs as number));
+    state = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 5_000,
+      sequence: 2,
+      phase: "active",
+      active: true,
+      activeScope: "tool",
+      activeSince: 5_000,
+      activityLabel: "bash",
+    }, 11_000);
 
-    assert.equal(classifyStatus(forced, stalledAt - 1).kind, "quiet");
-    assert.equal(classifyStatus(forced, stalledAt).kind, "stalled");
+    const snapshot = classifyStatus(state, 11_000);
+    assert.equal(snapshot.kind, "active");
+    assert.equal(snapshot.statusLabel, null);
   });
 
-  it("forces an already stalled state back to quiet until the timeout elapses again", () => {
-    const now = 95_000;
-    let state = createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 });
-    state = observeStatus(state, { entries: 2, bytes: 200 }, 5_000);
+  it("ignores stale and exact old snapshots after interrupt and accepts newer snapshots", () => {
+    let state = createStatusState({ source: "pi", startTimeMs: 0 });
+    state = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 5_000,
+      sequence: 1,
+      phase: "active",
+      active: true,
+      activeScope: "tool",
+      activeSince: 5_000,
+      activityLabel: "bash",
+    }, 5_000);
+    state = forceStatusAfterInterrupt(state, 20_000);
 
-    assert.equal(classifyStatus(state, now).kind, "stalled");
+    const stale = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 5_000,
+      sequence: 1,
+      phase: "active",
+      active: true,
+      activeScope: "tool",
+      activeSince: 5_000,
+      activityLabel: "bash",
+    }, 21_000);
+    let snapshot = classifyStatus(stale, 21_000);
+    assert.equal(snapshot.kind, "waiting");
+    assert.equal(snapshot.activityLabel, "interrupted");
 
-    const forced = forceStatusQuiet(state, now);
-    const forcedSnapshot = classifyStatus(forced, now);
-    const stalledAgainAt = now + (getStalledAfterMs(forced.cadenceMs) - (forcedSnapshot.idleMs as number));
+    const sameTimestamp = observeStatus(stale, {
+      snapshot: "present",
+      updatedAt: 20_000,
+      sequence: 1,
+      phase: "active",
+      active: true,
+      activeScope: "tool",
+      activeSince: 20_000,
+      activityLabel: "bash",
+    }, 22_000);
+    snapshot = classifyStatus(sameTimestamp, 22_000);
+    assert.equal(snapshot.kind, "waiting");
+    assert.equal(snapshot.activityLabel, "interrupted");
 
-    assert.equal(forcedSnapshot.kind, "quiet");
-    assert.equal(classifyStatus(forced, stalledAgainAt - 1).kind, "quiet");
-    assert.equal(classifyStatus(forced, stalledAgainAt).kind, "stalled");
-  });
-
-  it("returns to active when genuine new progress arrives after quiet is forced", () => {
-    const forcedAt = 20_000;
-    let state = createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 });
-    state = observeStatus(state, { entries: 2, bytes: 200 }, 5_000);
-    state = forceStatusQuiet(state, forcedAt);
-
-    const resumed = observeStatus(state, { entries: 3, bytes: 300 }, 25_000);
-
-    assert.equal(classifyStatus(resumed, 25_000).kind, "active");
-    assert.equal(resumed.observedEntries, 3);
-    assert.equal(resumed.observedBytes, 300);
+    const resumed = observeStatus(sameTimestamp, {
+      snapshot: "present",
+      sequence: 2,
+      updatedAt: 25_000,
+      phase: "active",
+      active: true,
+      activeScope: "streaming",
+      activeSince: 25_000,
+      activityLabel: "streaming",
+    }, 25_000);
+    snapshot = classifyStatus(resumed, 25_000);
+    assert.equal(snapshot.kind, "active");
+    assert.equal(resumed.activeScope, "streaming");
   });
 
   it("normalizes and truncates long newline-heavy names", () => {
     const longName = `Worker\n\n${"very-long-name-".repeat(12)}`;
-    const line = formatStatusLine(longName, {
-      kind: "stalled",
-      elapsedMs: 240_000,
-      elapsedText: "4m",
-      idleMs: 240_000,
-      idleText: "4m",
-      progressEvents: 0,
-    });
-    const recovered = formatTransitionLine(
-      longName,
-      {
-        kind: "active",
-        elapsedMs: 300_000,
-        elapsedText: "5m",
-        idleMs: 1_000,
-        idleText: "1s",
-        progressEvents: 2,
-      },
-      "recovered",
+    const stalledState = observeStatus(
+      createStatusState({ source: "pi", startTimeMs: 0 }),
+      { snapshot: "missing" },
+      1_000,
     );
+    const activeState = observeStatus(
+      createStatusState({ source: "pi", startTimeMs: 0 }),
+      {
+        snapshot: "present",
+        updatedAt: 299_000,
+        sequence: 1,
+        phase: "active",
+        active: true,
+        activeScope: "tool",
+        activeSince: 299_000,
+        activityLabel: "write",
+      },
+      299_000,
+    );
+    const line = formatStatusLine(longName, classifyStatus(stalledState, 240_000));
+    const recovered = formatTransitionLine(longName, classifyStatus(activeState, 300_000), "recovered");
 
     assert.doesNotMatch(line, /\n/);
     assert.doesNotMatch(recovered, /\n/);
@@ -666,33 +758,34 @@ describe("status.ts", () => {
   });
 
   it("caps visible status lines and reports overflow consistently", () => {
-    const quietLine = formatStatusLine("Worker", {
-      kind: "quiet",
-      elapsedMs: 300_000,
-      elapsedText: "5m",
-      idleMs: 120_000,
-      idleText: "2m",
-      progressEvents: 0,
-    });
-    const recoveredLine = formatTransitionLine(
-      "Worker",
-      {
-        kind: "active",
-        elapsedMs: 420_000,
-        elapsedText: "7m",
-        idleMs: 1_000,
-        idleText: "1s",
-        progressEvents: 3,
-      },
-      "recovered",
+    const waitingState = observeStatus(
+      createStatusState({ source: "pi", startTimeMs: 0 }),
+      { snapshot: "present", updatedAt: 180_000, sequence: 1, phase: "waiting", waitingSince: 180_000 },
+      180_000,
     );
-    const lines = [quietLine, recoveredLine, "Scout running 2m.", "Reviewer running 4m.", "Planner running 6m."];
+    const activeState = observeStatus(
+      createStatusState({ source: "pi", startTimeMs: 0 }),
+      {
+        snapshot: "present",
+        updatedAt: 419_000,
+        sequence: 1,
+        phase: "active",
+        active: true,
+        activeScope: "tool",
+        activeSince: 419_000,
+        activityLabel: "bash",
+      },
+      419_000,
+    );
+    const waitingLine = formatStatusLine("Worker", classifyStatus(waitingState, 300_000));
+    const recoveredLine = formatTransitionLine("Worker", classifyStatus(activeState, 420_000), "recovered");
+    const lines = [waitingLine, recoveredLine, "Scout running 2m.", "Reviewer running 4m.", "Planner running 6m."];
     const capped = capStatusLines(lines, 3);
     const aggregate = formatStatusAggregate(lines, 3);
 
-    assert.equal(quietLine, "Worker running 5m, quiet 2m.");
-    assert.equal(recoveredLine, "Worker running 7m, recovered; active (+3 events).");
-    assert.deepEqual(capped.visibleLines, [quietLine, recoveredLine, "Scout running 2m."]);
+    assert.equal(waitingLine, "Worker running 5m, waiting 2m.");
+    assert.equal(recoveredLine, "Worker running 7m, recovered; active (bash 1s).");
+    assert.deepEqual(capped.visibleLines, [waitingLine, recoveredLine, "Scout running 2m."]);
     assert.equal(capped.overflow, 2);
     assert.match(aggregate, /^Subagent status:/);
     assert.match(aggregate, /\+2 more running\./);
@@ -772,7 +865,7 @@ describe("subagent discovery", () => {
       testApi.resolveEffectiveInteractive({ name: "A", task: "T" }, { autoExit: true }),
       false,
     );
-    // Agents without auto-exit ARE interactive — parent stays quiet on stalls.
+    // Agents without auto-exit ARE interactive — parent does not receive status transition pings.
     assert.equal(
       testApi.resolveEffectiveInteractive({ name: "A", task: "T" }, { autoExit: false }),
       true,
@@ -1095,16 +1188,198 @@ describe("tool registration", () => {
     assert.equal(denied.has("subagent_interrupt"), true);
     assert.equal(denied.has("subagent_resume"), true);
   });
+
+  it("renders partial subagent tool-call args without throwing", () => {
+    const { api, registeredTools } = createMockExtensionApi();
+    (subagentsModule as any).default(api);
+
+    const subagentTool = registeredTools.find((tool) => tool.name === "subagent");
+    assert.ok(subagentTool, "expected subagent tool to be registered");
+
+    const theme = {
+      fg(_color: string, text: string) {
+        return text;
+      },
+      bold(text: string) {
+        return text;
+      },
+    };
+    const rendered = subagentTool.renderCall({}, theme);
+    const output = rendered.render(80).join("\n");
+
+    assert.match(output, /\(unnamed\)/);
+  });
 });
 
-describe("session progress observation", () => {
-  it("ignores only transient session-file races", () => {
-    const testApi = (subagentsModule as any).__test__;
+describe("subagent activity snapshots", () => {
+  function validActivity(overrides: Record<string, unknown> = {}) {
+    return {
+      version: 1,
+      runningChildId: "child-1",
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      sequence: 1,
+      latestEvent: "session_start",
+      phase: "starting",
+      agentActive: false,
+      turnActive: false,
+      providerActive: false,
+      toolActive: false,
+      ...overrides,
+    };
+  }
 
-    assert.equal(testApi.isIgnorableSessionProgressError({ code: "ENOENT" }), true);
-    assert.equal(testApi.isIgnorableSessionProgressError({ code: "EBUSY" }), true);
-    assert.equal(testApi.isIgnorableSessionProgressError({ code: "EACCES" }), false);
-    assert.equal(testApi.isIgnorableSessionProgressError(new Error("boom")), false);
+  it("writes and validates activity files by running child id", () => {
+    withTempDir((dir) => {
+      const activityFile = getSubagentActivityFile(dir, "child-1");
+      const recorder = createSubagentActivityRecorder({
+        runningChildId: "child-1",
+        activityFile,
+        now: () => 1_000,
+      });
+
+      recorder.sessionStart();
+      recorder.toolExecutionStart("tool-1", "bash");
+
+      const read = readSubagentActivityFile(activityFile, "child-1");
+      assert.ok(read.ok);
+      assert.equal(read.activity.phase, "active");
+      assert.equal(read.activity.activeScope, "tool");
+      assert.equal(read.activity.toolName, "bash");
+
+      assert.deepEqual(readSubagentActivityFile(activityFile, "other-child"), {
+        ok: false,
+        reason: "wrong-id",
+      });
+    });
+  });
+
+  it("records waiting and final done states", () => {
+    withTempDir((dir) => {
+      let currentNow = 2_000;
+      const activityFile = getSubagentActivityFile(dir, "child-2");
+      const recorder = createSubagentActivityRecorder({
+        runningChildId: "child-2",
+        activityFile,
+        now: () => currentNow,
+      });
+
+      recorder.sessionStart();
+      currentNow = 3_000;
+      recorder.agentEndWaiting();
+      let read = readSubagentActivityFile(activityFile, "child-2");
+      assert.ok(read.ok);
+      assert.equal(read.activity.phase, "waiting");
+      assert.equal(read.activity.waitingSince, 3_000);
+
+      currentNow = 4_000;
+      recorder.subagentDone();
+      read = readSubagentActivityFile(activityFile, "child-2");
+      assert.ok(read.ok);
+      assert.equal(read.activity.phase, "done");
+      assert.equal(read.activity.agentActive, false);
+    });
+  });
+
+  it("rejects malformed activity fields used by classification and rendering", () => {
+    withTempDir((dir) => {
+      mkdirSync(join(dir, "subagent-activity"), { recursive: true });
+      const cases = [
+        { activeSince: "bad" },
+        { waitingSince: "bad" },
+        { activeScope: "database" },
+        { latestEvent: "unknown" },
+        { runningChildId: 42 },
+        { toolActive: "yes" },
+        { toolName: "bad\nname" },
+      ];
+
+      for (const [index, overrides] of cases.entries()) {
+        const activityFile = getSubagentActivityFile(dir, `child-${index}`);
+        const activity = validActivity({ runningChildId: `child-${index}`, ...overrides });
+        writeFileSync(activityFile, `${JSON.stringify(activity)}\n`);
+
+        const read = readSubagentActivityFile(activityFile, `child-${index}`);
+        assert.equal(read.ok, false);
+        assert.equal((read as { ok: false; reason: string }).reason, "invalid");
+      }
+    });
+  });
+
+  it("does not let tool_result resurrect finished tool activity", () => {
+    withTempDir((dir) => {
+      let currentNow = 1_000;
+      const activityFile = getSubagentActivityFile(dir, "child-3");
+      const recorder = createSubagentActivityRecorder({
+        runningChildId: "child-3",
+        activityFile,
+        now: () => currentNow,
+      });
+
+      recorder.sessionStart();
+      recorder.agentStart();
+      recorder.turnStart(1);
+      currentNow = 2_000;
+      recorder.toolExecutionStart("tool-1", "bash");
+      currentNow = 3_000;
+      recorder.toolExecutionEnd("tool-1", "bash");
+      currentNow = 4_000;
+      recorder.toolResult("tool-1", "bash");
+
+      const read = readSubagentActivityFile(activityFile, "child-3");
+      assert.ok(read.ok);
+      assert.equal(read.activity.toolActive, false);
+      assert.equal(read.activity.activeScope, "turn");
+    });
+  });
+
+  it("does not mark reload shutdown as the final done snapshot", () => {
+    withTempDir((dir) => {
+      const activityFile = getSubagentActivityFile(dir, "child-4");
+      const recorder = createSubagentActivityRecorder({
+        runningChildId: "child-4",
+        activityFile,
+        now: () => 1_000,
+      });
+
+      recorder.sessionStart();
+      recorder.sessionShutdown("reload");
+
+      const read = readSubagentActivityFile(activityFile, "child-4");
+      assert.ok(read.ok);
+      assert.equal(read.activity.phase, "starting");
+      assert.equal(read.activity.latestEvent, "session_start");
+    });
+  });
+
+  it("cancels pending throttled writes on reload shutdown", async () => {
+    const dir = createTestDir();
+    try {
+      await new Promise<void>((resolve) => {
+        let currentNow = 1_000;
+        const activityFile = getSubagentActivityFile(dir, "child-5");
+        const recorder = createSubagentActivityRecorder({
+          runningChildId: "child-5",
+          activityFile,
+          now: () => currentNow,
+        });
+
+        recorder.sessionStart();
+        currentNow = 1_100;
+        recorder.messageUpdate("delta");
+        recorder.sessionShutdown("reload");
+
+        setTimeout(() => {
+          const read = readSubagentActivityFile(activityFile, "child-5");
+          assert.ok(read.ok);
+          assert.equal(read.activity.phase, "starting");
+          assert.equal(read.activity.latestEvent, "session_start");
+          resolve();
+        }, 650);
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -1118,7 +1393,7 @@ describe("subagent interruption", () => {
       startTime: 0,
       sessionFile: "worker.jsonl",
       interactive: false,
-      statusState: createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 }),
+      statusState: createStatusState({ source: "pi", startTimeMs: 0 }),
       ...overrides,
     };
   }
@@ -1177,8 +1452,17 @@ describe("subagent interruption", () => {
     runningMap.clear();
 
     const activeState = observeStatus(
-      createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 }),
-      { entries: 1, bytes: 100 },
+      createStatusState({ source: "pi", startTimeMs: 0 }),
+      {
+        snapshot: "present",
+        updatedAt: 5_000,
+        sequence: 1,
+        phase: "active",
+        active: true,
+        activeScope: "tool",
+        activeSince: 5_000,
+        activityLabel: "bash",
+      },
       5_000,
     );
 
@@ -1218,23 +1502,80 @@ describe("subagent interruption", () => {
     assert.equal("interruptRequested" in running, false);
   });
 
-  it("acknowledges Pi-backed interrupt requests and forces local status quiet", () => {
+  it("refreshes the latest activity snapshot before forcing local interrupt waiting", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const runningMap = testApi.runningSubagents as Map<string, any>;
+    let sentSurface = "";
+    runningMap.clear();
+
+    withTempDir((dir) => {
+      mkdirSync(join(dir, "subagent-activity"), { recursive: true });
+      const activityFile = getSubagentActivityFile(dir, "a1");
+      const activity = {
+        version: 1,
+        runningChildId: "a1",
+        createdAt: 1_000,
+        updatedAt: 19_000,
+        sequence: 7,
+        latestEvent: "tool_execution_start",
+        phase: "active",
+        agentActive: true,
+        turnActive: true,
+        providerActive: false,
+        toolActive: true,
+        activeScope: "tool",
+        activeSince: 19_000,
+        toolName: "bash",
+      };
+      writeFileSync(activityFile, `${JSON.stringify(activity)}\n`);
+
+      try {
+        runningMap.set("a1", makeRunning({
+          activityFile,
+          statusState: createStatusState({ source: "pi", startTimeMs: 0 }),
+        }));
+
+        withMockedNow(20_000, () => testApi.handleSubagentInterrupt({ name: "Worker" }, (surface: string) => {
+          sentSurface = surface;
+        }));
+
+        assert.equal(sentSurface, "pane-1");
+        const state = runningMap.get("a1").statusState;
+        const snapshot = classifyStatus(state, 20_000);
+        assert.equal(snapshot.kind, "waiting");
+        assert.equal(snapshot.activityLabel, "interrupted");
+        assert.equal(state.lastActivityAtMs, 20_000);
+        assert.equal(state.lastActivitySequence, 7);
+        assert.equal(state.localOverrideSequence, 7);
+      } finally {
+        runningMap.clear();
+      }
+    });
+  });
+
+  it("acknowledges Pi-backed interrupt requests and forces local status waiting", () => {
     const testApi = (subagentsModule as any).__test__;
     const runningMap = testApi.runningSubagents as Map<string, any>;
     let sentSurface = "";
     runningMap.clear();
 
     const activeState = observeStatus(
-      createStatusState({ source: "pi", startTimeMs: 0, cadenceMs: 30_000 }),
-      { entries: 1, bytes: 100 },
+      createStatusState({ source: "pi", startTimeMs: 0 }),
+      {
+        snapshot: "present",
+        updatedAt: 5_000,
+        sequence: 1,
+        phase: "active",
+        active: true,
+        activeScope: "tool",
+        activeSince: 5_000,
+        activityLabel: "bash",
+      },
       5_000,
     );
 
     try {
-      runningMap.set("a1", makeRunning({
-        sessionFile: "/tmp/does-not-exist.jsonl",
-        statusState: activeState,
-      }));
+      runningMap.set("a1", makeRunning({ statusState: activeState }));
 
       const result = withMockedNow(20_000, () => testApi.handleSubagentInterrupt({ name: "Worker" }, (surface: string) => {
         sentSurface = surface;
@@ -1243,7 +1584,9 @@ describe("subagent interruption", () => {
       assert.equal(sentSurface, "pane-1");
       assert.equal(result.content[0].text, 'Interrupt requested for subagent "Worker".');
       assert.deepEqual(result.details, { id: "a1", name: "Worker", status: "interrupt_requested" });
-      assert.equal(classifyStatus(runningMap.get("a1").statusState, 20_000).kind, "quiet");
+      const snapshot = classifyStatus(runningMap.get("a1").statusState, 20_000);
+      assert.equal(snapshot.kind, "waiting");
+      assert.equal(snapshot.activityLabel, "interrupted");
       assert.equal(runningMap.has("a1"), true);
     } finally {
       runningMap.clear();
@@ -1339,15 +1682,15 @@ describe("subagent status renderer", () => {
     assert.ok(rendererEntry, "expected subagent_status renderer to be registered");
 
     const visibleLines = [
-      "Worker running 5m, stalled 5m.",
-      "Scout running 3m, stalled 3m.",
-      "Reviewer running 2m, stalled 2m.",
-      "Planner running 4m, stalled 4m.",
+      "Worker running 5m, active (bash 2m).",
+      "Scout running 3m, waiting 1m.",
+      "Reviewer running 2m, active (streaming 30s).",
+      "Planner running 4m, waiting 2m.",
     ];
     const rendered = rendererEntry.renderer(
       {
         customType: "subagent_status",
-        content: "Subagent status:\n• Worker running 5m, stalled 5m.",
+        content: "Subagent status:\n• Worker running 5m, active (bash 2m).",
         details: {
           lines: visibleLines,
           overflow: 2,
@@ -1375,8 +1718,8 @@ describe("subagent status renderer", () => {
     const rendered = rendererEntry.renderer(
       {
         customType: "subagent_status",
-        content: "Subagent status:\n• Worker running 5m, stalled 5m.",
-        details: { lines: ["Worker running 5m, stalled 5m."], overflow: 0 },
+        content: "Subagent status:\n• Worker running 5m, active (bash 2m).",
+        details: { lines: ["Worker running 5m, active (bash 2m)."], overflow: 0 },
       },
       { expanded: true },
       createTheme(),
@@ -1441,9 +1784,7 @@ describe("subagents widget rendering", () => {
           surface: "s1",
           startTime: 1_000_000 - 13_000,
           sessionFile: "sess1",
-          entries: 13,
-          bytes: 55.6 * 1024,
-          statusState: createStatusState({ source: "pi", startTimeMs: 1_000_000 - 13_000, cadenceMs: 30_000 }),
+          statusState: createStatusState({ source: "pi", startTimeMs: 1_000_000 - 13_000 }),
         },
         {
           id: "a2",
@@ -1452,9 +1793,7 @@ describe("subagents widget rendering", () => {
           surface: "s2",
           startTime: 1_000_000 - 21_000,
           sessionFile: "sess2",
-          entries: 21,
-          bytes: 115.6 * 1024,
-          statusState: createStatusState({ source: "pi", startTimeMs: 1_000_000 - 21_000, cadenceMs: 30_000 }),
+          statusState: createStatusState({ source: "pi", startTimeMs: 1_000_000 - 21_000 }),
         },
         {
           id: "a3",
@@ -1463,9 +1802,7 @@ describe("subagents widget rendering", () => {
           surface: "s3",
           startTime: 1_000_000 - 27_000,
           sessionFile: "sess3",
-          entries: 27,
-          bytes: 106.8 * 1024,
-          statusState: createStatusState({ source: "pi", startTimeMs: 1_000_000 - 27_000, cadenceMs: 30_000 }),
+          statusState: createStatusState({ source: "pi", startTimeMs: 1_000_000 - 27_000 }),
         },
       ], 16);
 
@@ -1503,9 +1840,7 @@ describe("subagents widget rendering", () => {
           surface: "s1",
           startTime,
           sessionFile: "sess1",
-          entries: 1,
-          bytes: 1,
-          statusState: createStatusState({ source: "pi", startTimeMs: startTime, cadenceMs: 30_000 }),
+          statusState: createStatusState({ source: "pi", startTimeMs: startTime }),
         },
       ], width);
 


### PR DESCRIPTION
Replaces Pi-backed subagent liveness detection with child-side activity state so parents only wake when supervision is actually unhealthy.  The old classifier inferred activity from session JSONL growth, which made legitimate long-running work look stalled whenever a child was streaming, waiting on a provider, constructing a tool call, or running a tool without writing a transcript entry yet.

Pi-backed children now write a small validated activity snapshot, and the parent status loop treats that snapshot as the canonical source for `starting`, `active`, `waiting`, and `stalled`.  Healthy `active` and `waiting` states do not age into `stalled` just because time passes; missing, invalid, wrong-id, or never-established activity state uses a fixed internal watchdog before waking non-interactive orchestrators.  Session JSONL remains responsible for transcripts, resume, lineage, and result extraction, but it is no longer used as the Pi-backed liveness signal.

Summary of changes:
  - activity: add shared subagent activity schema, validated reader, atomic writer, throttled child recorder, and shutdown-safe pending write cancellation
  - child extension: record session, input, agent, turn, provider, message streaming, tool, caller ping, done, and shutdown lifecycle events
  - parent orchestration: pass activity file env vars on launch/resume and classify Pi-backed children from activity files instead of JSONL growth
  - status: replace JSONL-growth-derived `quiet`/stalled behavior with activity-derived `starting`, `active`, `waiting`, `stalled`, and elapsed-only `running`
  - watchdog: remove public `statusCadenceSeconds` / `defaultCadenceSeconds` tuning and use fixed `TELEMETRY_STALLED_AFTER_MS = 60_000` for broken activity-state supervision
  - config: leave `status.enabled` as the only documented status setting and reject obsolete status config keys instead of silently ignoring them
  - ordering: use activity `sequence` with `updatedAt` to accept legitimate same-millisecond child updates and recover after transient activity-read failures
  - interrupt: refresh activity before forcing local `waiting` / `interrupted`, block stale activity snapshots from resurrecting pre-interrupt active state, and allow newer snapshots to recover
  - resume: assign resumed handles a fresh activity file keyed by the new running id and default resumed sessions to `interactive: true`
  - docs: update README status, child activity, config, interrupt, and tool parameter documentation for the activity-state model
  - tests: cover activity-state classification, activity file validation, malformed/wrong-id snapshots, same-millisecond ordering, transient read failure recovery, stale cadence rejection, pending recorder shutdown writes, interrupt waiting state, widget/status formatting, and long-tool no-false-stall behavior
  
Testing:
- `npm test` - all pass
- `npm run test:integration` - all pass
- Manually e2e verified the new behaviors in toy scenarios and in two actual stress-test scenarios