### PR TITLE
fix: preserve mux focus during subagent launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ If your shell startup is slow and subagent commands sometimes get dropped before
 export PI_SUBAGENT_SHELL_READY_DELAY_MS=2500
 ```
 
+Subagent panes are created without stealing keyboard focus (cmux, tmux). Launch commands target child surfaces by explicit ID, so focus and command delivery are independent. Note: the `interactive` option controls parent status notifications, not terminal focus.
+
 ## What's Included
 
 ### Extensions

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "test": "node --test test/test.ts",
-    "test:integration": "node --test test/integration/*.test.ts"
+    "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
   },
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": "*",

--- a/pi-extension/subagents/cmux.ts
+++ b/pi-extension/subagents/cmux.ts
@@ -1,4 +1,4 @@
-import { execSync, execFile, execFileSync } from "node:child_process";
+import { execSync, execFile, execFileSync, spawnSync } from "node:child_process";
 import { promisify } from "node:util";
 import { existsSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -188,6 +188,220 @@ async function zellijActionAsync(args: string[], surface?: string): Promise<stri
 /** Tracked subagent pane for cmux — reused across subagent launches. */
 let cmuxSubagentPane: string | null = null;
 
+type CmuxFocusSnapshot = {
+  surfaceRef?: string;
+  paneRef?: string;
+};
+
+type CmuxCreatedSurface = {
+  surface: string;
+  paneRef?: string;
+};
+
+type CmuxIdentifySnapshot = {
+  focused: CmuxFocusSnapshot | null;
+  caller: CmuxFocusSnapshot | null;
+};
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+export function parseCmuxFocusedSnapshot(value: unknown): CmuxFocusSnapshot | null {
+  if (!value || typeof value !== "object") return null;
+
+  const focused = (value as { focused?: unknown }).focused;
+  if (!focused || typeof focused !== "object") return null;
+
+  const record = focused as { surface_ref?: unknown; pane_ref?: unknown };
+  const surfaceRef = nonEmptyString(record.surface_ref) ? record.surface_ref : undefined;
+  const paneRef = nonEmptyString(record.pane_ref) ? record.pane_ref : undefined;
+
+  if (!surfaceRef && !paneRef) return null;
+  return { surfaceRef, paneRef };
+}
+
+export function parseCmuxJson(value: string): unknown | null {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    void error;
+    return null;
+  }
+}
+
+export function parseCmuxFocusedSnapshotFromJson(value: string): CmuxFocusSnapshot | null {
+  return parseCmuxFocusedSnapshot(parseCmuxJson(value));
+}
+
+function parseCmuxCallerSnapshot(value: unknown): CmuxFocusSnapshot | null {
+  if (!value || typeof value !== "object") return null;
+
+  const caller = (value as { caller?: unknown }).caller;
+  if (!caller || typeof caller !== "object") return null;
+
+  const record = caller as { surface_ref?: unknown; pane_ref?: unknown };
+  const surfaceRef = nonEmptyString(record.surface_ref) ? record.surface_ref : undefined;
+  const paneRef = nonEmptyString(record.pane_ref) ? record.pane_ref : undefined;
+
+  if (!surfaceRef && !paneRef) return null;
+  return { surfaceRef, paneRef };
+}
+
+export function parseCmuxPaneRefForSurface(value: unknown, surface: string): string | null {
+  if (!value || typeof value !== "object") return null;
+
+  const record = value as { surface_ref?: unknown; pane_ref?: unknown; caller?: unknown };
+  if (record.surface_ref === surface && nonEmptyString(record.pane_ref)) return record.pane_ref;
+
+  const caller = record.caller;
+  if (!caller || typeof caller !== "object") return null;
+
+  const callerRecord = caller as { surface_ref?: unknown; pane_ref?: unknown };
+  if (callerRecord.surface_ref === surface && nonEmptyString(callerRecord.pane_ref)) {
+    return callerRecord.pane_ref;
+  }
+
+  return null;
+}
+
+export function parseCmuxPaneRefForSurfaceFromJson(value: string, surface: string): string | null {
+  return parseCmuxPaneRefForSurface(parseCmuxJson(value), surface);
+}
+
+function readCmux(args: string[]): string | null {
+  const result = spawnSync("cmux", args, { encoding: "utf8" });
+  if (result.error || result.status !== 0 || !result.stdout.trim()) return null;
+  return result.stdout;
+}
+
+function parseCmuxIdentifySnapshot(value: string | null): CmuxIdentifySnapshot {
+  const parsed = value ? parseCmuxJson(value) : null;
+  return {
+    focused: parseCmuxFocusedSnapshot(parsed),
+    caller: parseCmuxCallerSnapshot(parsed),
+  };
+}
+
+function captureCmuxIdentifySnapshot(): CmuxIdentifySnapshot {
+  return parseCmuxIdentifySnapshot(readCmux(["identify", "--json"]));
+}
+
+function captureCmuxFocusSnapshot(): CmuxFocusSnapshot | null {
+  return captureCmuxIdentifySnapshot().focused;
+}
+
+function readCmuxPaneRefForSurface(surface: string): string | null {
+  const info = readCmux(["identify", "--surface", surface]);
+  return info ? parseCmuxPaneRefForSurfaceFromJson(info, surface) : null;
+}
+
+function restoreCmuxFocusSnapshot(snapshot: CmuxFocusSnapshot | null): void {
+  if (!snapshot) return;
+
+  if (snapshot.paneRef) {
+    spawnSync("cmux", ["focus-pane", "--pane", snapshot.paneRef], { encoding: "utf8" });
+  }
+
+  if (snapshot.surfaceRef) {
+    spawnSync("cmux", ["focus-panel", "--panel", snapshot.surfaceRef], { encoding: "utf8" });
+  }
+}
+
+function waitForCmuxFocusSettle(): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
+}
+
+function cmuxFocusMatchesChild(
+  currentFocus: CmuxFocusSnapshot | null,
+  child: CmuxCreatedSurface,
+): boolean {
+  if (!currentFocus) return false;
+  if (currentFocus.surfaceRef === child.surface) return true;
+  return !!currentFocus.paneRef && currentFocus.paneRef === child.paneRef;
+}
+
+function cmuxFocusMatchesSurfaceRef(
+  currentFocus: CmuxFocusSnapshot | null,
+  surfaceRef: string | undefined,
+): boolean {
+  return !!surfaceRef && currentFocus?.surfaceRef === surfaceRef;
+}
+
+function cmuxFocusMatchesPaneRef(
+  currentFocus: CmuxFocusSnapshot | null,
+  paneRef: string | undefined,
+): boolean {
+  return !!paneRef && currentFocus?.paneRef === paneRef;
+}
+
+function restoreCmuxFocusIfLaunchSurfaceFocused(
+  snapshot: CmuxFocusSnapshot | null,
+  child: CmuxCreatedSurface,
+  options?: { sourceSurfaceRef?: string; callerSnapshot?: CmuxFocusSnapshot | null },
+): void {
+  if (!snapshot) return;
+
+  waitForCmuxFocusSettle();
+  const currentFocus = captureCmuxFocusSnapshot();
+  if (
+    cmuxFocusMatchesChild(currentFocus, child) ||
+    cmuxFocusMatchesSurfaceRef(currentFocus, options?.sourceSurfaceRef) ||
+    cmuxFocusMatchesSurfaceRef(currentFocus, options?.callerSnapshot?.surfaceRef) ||
+    // cmux can settle focus onto another active surface in the caller pane after creating a split/surface.
+    cmuxFocusMatchesPaneRef(currentFocus, options?.callerSnapshot?.paneRef)
+  ) {
+    restoreCmuxFocusSnapshot(snapshot);
+  }
+}
+
+function parseCmuxCreatedSurface(output: string, command: string): CmuxCreatedSurface {
+  const surfaceMatch = output.match(/surface:\d+/);
+  if (!surfaceMatch) {
+    throw new Error(`Unexpected cmux ${command} output: ${output}`);
+  }
+
+  return {
+    surface: surfaceMatch[0],
+    paneRef: output.match(/pane:\d+/)?.[0],
+  };
+}
+
+function renameCmuxSurface(surface: string, name: string): void {
+  execFileSync("cmux", ["rename-tab", "--surface", surface, name], { encoding: "utf8" });
+}
+
+function createCmuxSplitSurface(
+  name: string,
+  direction: "left" | "right" | "up" | "down",
+  fromSurface?: string,
+): CmuxCreatedSurface {
+  const identifySnapshot = captureCmuxIdentifySnapshot();
+  const focusSnapshot = identifySnapshot.focused;
+  const callerSnapshot = identifySnapshot.caller;
+  let child: CmuxCreatedSurface | null = null;
+
+  try {
+    const args = ["new-split", direction];
+    if (fromSurface) args.push("--surface", fromSurface);
+
+    const output = execFileSync("cmux", args, { encoding: "utf8" }).trim();
+    child = parseCmuxCreatedSurface(output, "new-split");
+    child.paneRef ??= readCmuxPaneRefForSurface(child.surface) ?? undefined;
+    renameCmuxSurface(child.surface, name);
+    return child;
+  } finally {
+    if (child) {
+      restoreCmuxFocusIfLaunchSurfaceFocused(focusSnapshot, child, {
+        sourceSurfaceRef: fromSurface,
+        callerSnapshot,
+      });
+    } else {
+      restoreCmuxFocusSnapshot(focusSnapshot);
+    }
+  }
+}
+
 /**
  * Create a new terminal surface for a subagent.
  *
@@ -212,44 +426,42 @@ export function createSurface(name: string): string {
     cmuxSubagentPane = null;
   }
 
+  if (backend === "cmux") {
+    const created = createCmuxSplitSurface(name, "right", process.env.CMUX_SURFACE_ID);
+    cmuxSubagentPane = created.paneRef ?? null;
+    return created.surface;
+  }
+
   // On tmux, target the parent pi's pane so splits follow the agent, not the user's focus.
   // See https://github.com/HazAT/pi-interactive-subagents/issues/12
   const fromSurface = backend === "tmux" ? process.env.TMUX_PANE : undefined;
-  const surface = createSurfaceSplit(name, "right", fromSurface);
-
-  // For cmux, remember the pane so future subagents become tabs in it
-  if (backend === "cmux") {
-    try {
-      const info = execSync(`cmux identify --surface ${shellEscape(surface)}`, {
-        encoding: "utf8",
-      });
-      const parsed = JSON.parse(info);
-      const paneRef = parsed?.caller?.pane_ref;
-      if (paneRef) {
-        cmuxSubagentPane = paneRef;
-      }
-    } catch {}
-  }
-
-  return surface;
+  return createSurfaceSplit(name, "right", fromSurface);
 }
 
 /**
  * Create a new surface (tab) in an existing cmux pane.
  */
 function createSurfaceInPane(name: string, pane: string): string {
-  const out = execSync(`cmux new-surface --pane ${shellEscape(pane)}`, {
-    encoding: "utf8",
-  }).trim();
-  const match = out.match(/surface:\d+/);
-  if (!match) {
-    throw new Error(`Unexpected cmux new-surface output: ${out}`);
+  const identifySnapshot = captureCmuxIdentifySnapshot();
+  const focusSnapshot = identifySnapshot.focused;
+  const callerSnapshot = identifySnapshot.caller;
+  let child: CmuxCreatedSurface | null = null;
+
+  try {
+    const output = execFileSync("cmux", ["new-surface", "--pane", pane], { encoding: "utf8" }).trim();
+    child = parseCmuxCreatedSurface(output, "new-surface");
+    child.paneRef ??= pane;
+    renameCmuxSurface(child.surface, name);
+    return child.surface;
+  } finally {
+    if (child) {
+      restoreCmuxFocusIfLaunchSurfaceFocused(focusSnapshot, child, {
+        callerSnapshot,
+      });
+    } else {
+      restoreCmuxFocusSnapshot(focusSnapshot);
+    }
   }
-  const surface = match[0];
-  execSync(`cmux rename-tab --surface ${shellEscape(surface)} ${shellEscape(name)}`, {
-    encoding: "utf8",
-  });
-  return surface;
 }
 
 /**
@@ -264,23 +476,11 @@ export function createSurfaceSplit(
   const backend = requireMuxBackend();
 
   if (backend === "cmux") {
-    const surfaceArg = fromSurface ? ` --surface ${shellEscape(fromSurface)}` : "";
-    const out = execSync(`cmux new-split ${direction}${surfaceArg}`, {
-      encoding: "utf8",
-    }).trim();
-    const match = out.match(/surface:\d+/);
-    if (!match) {
-      throw new Error(`Unexpected cmux new-split output: ${out}`);
-    }
-    const surface = match[0];
-    execSync(`cmux rename-tab --surface ${shellEscape(surface)} ${shellEscape(name)}`, {
-      encoding: "utf8",
-    });
-    return surface;
+    return createCmuxSplitSurface(name, direction, fromSurface).surface;
   }
 
   if (backend === "tmux") {
-    const args = ["split-window"];
+    const args = ["split-window", "-d"];
     if (direction === "left" || direction === "right") {
       args.push("-h");
     } else {
@@ -299,11 +499,6 @@ export function createSurfaceSplit(
       throw new Error(`Unexpected tmux split-window output: ${pane}`);
     }
 
-    try {
-      execFileSync("tmux", ["select-pane", "-t", pane, "-T", name], { encoding: "utf8" });
-    } catch {
-      // Optional.
-    }
     return pane;
   }
 
@@ -708,7 +903,7 @@ export async function pollForExit(
 ): Promise<PollResult> {
   const start = Date.now();
 
-  while (true) {
+  for (;;) {
     if (signal.aborted) {
       throw new Error("Aborted while waiting for subagent to finish");
     }

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -8,6 +8,7 @@
  * - Poll for file creation and screen output
  * - Clean up surfaces and temp files after tests
  */
+import { execFileSync } from "node:child_process";
 import {
   mkdtempSync,
   mkdirSync,
@@ -32,6 +33,8 @@ import {
   closeSurface,
   sendEscape,
   shellEscape,
+  parseCmuxFocusedSnapshotFromJson,
+  parseCmuxPaneRefForSurfaceFromJson,
   type MuxBackend,
 } from "../../pi-extension/subagents/cmux.ts";
 
@@ -110,6 +113,71 @@ export function restoreBackend(prev: string | undefined): void {
   else process.env.PI_SUBAGENT_MUX = prev;
 }
 
+export function focusSurface(backend: MuxBackend, surface: string): void {
+  if (backend === "cmux") {
+    const pane = getSurfacePane(backend, surface);
+    if (pane) execFileSync("cmux", ["focus-pane", "--pane", pane], { encoding: "utf8" });
+    execFileSync("cmux", ["focus-panel", "--panel", surface], { encoding: "utf8" });
+    return;
+  }
+
+  if (backend === "tmux") {
+    execFileSync("tmux", ["select-pane", "-t", surface], { encoding: "utf8" });
+    return;
+  }
+
+  throw new Error(`Focus helpers are not implemented for ${backend}`);
+}
+
+export function getFocusedSurface(backend: MuxBackend): string | null {
+  if (backend === "cmux") {
+    const info = execFileSync("cmux", ["identify", "--json"], { encoding: "utf8" });
+    return parseCmuxFocusedSnapshotFromJson(info)?.surfaceRef ?? null;
+  }
+
+  if (backend === "tmux") {
+    try {
+      const panes = execFileSync("tmux", ["list-panes", "-F", "#{pane_id} #{pane_active}"], {
+        encoding: "utf8",
+      });
+      const activeLine = panes.split("\n").find((line) => line.endsWith(" 1"));
+      return activeLine?.split(" ")[0] ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  throw new Error(`Focus helpers are not implemented for ${backend}`);
+}
+
+export function getSurfacePane(backend: MuxBackend, surface: string): string | null {
+  if (backend === "cmux") {
+    const info = execFileSync("cmux", ["identify", "--surface", surface], { encoding: "utf8" });
+    return parseCmuxPaneRefForSurfaceFromJson(info, surface);
+  }
+
+  if (backend === "tmux") return surface;
+
+  throw new Error(`Pane lookup is not implemented for ${backend}`);
+}
+
+export async function waitForFocusedSurface(
+  backend: MuxBackend,
+  surface: string,
+  timeout: number = PI_TIMEOUT,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    if (getFocusedSurface(backend) === surface) return;
+    await sleep(200);
+  }
+
+  throw new Error(
+    `Timeout (${timeout}ms) waiting for focused ${backend} surface ${surface}; ` +
+      `current focus is ${getFocusedSurface(backend) ?? "unknown"}`,
+  );
+}
+
 // ── Test environment ──
 
 export interface TestEnv {
@@ -168,6 +236,17 @@ export function cleanupTestEnv(env: TestEnv): void {
  */
 export function createTrackedSurface(env: TestEnv, name: string): string {
   const surface = createSurface(name);
+  env.surfaces.push(surface);
+  return surface;
+}
+
+export function createTrackedSurfaceSplit(
+  env: TestEnv,
+  name: string,
+  direction: "left" | "right" | "up" | "down",
+  fromSurface?: string,
+): string {
+  const surface = createSurfaceSplit(name, direction, fromSurface);
   env.surfaces.push(surface);
   return surface;
 }

--- a/test/integration/mux-surface.test.ts
+++ b/test/integration/mux-surface.test.ts
@@ -11,7 +11,7 @@
  */
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { unlinkSync } from "node:fs";
 import {
   getAvailableBackends,
   setBackend,
@@ -19,6 +19,11 @@ import {
   createTestEnv,
   cleanupTestEnv,
   createTrackedSurface,
+  createTrackedSurfaceSplit,
+  focusSurface,
+  getFocusedSurface,
+  getSurfacePane,
+  waitForFocusedSurface,
   untrackSurface,
   sendCommand,
   sendLongCommand,
@@ -35,6 +40,7 @@ import {
 } from "./harness.ts";
 
 const backends = getAvailableBackends();
+const FOCUS_TEST_SHELL_READY_DELAY_MS = Number(process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS ?? "2500");
 
 if (backends.length === 0) {
   console.log("⚠️  No mux backend available — skipping mux-surface integration tests");
@@ -54,6 +60,41 @@ for (const backend of backends) {
     after(() => {
       cleanupTestEnv(env);
       restoreBackend(prevMux);
+    });
+
+    it("keeps focus on the active surface while creating and targeting subagent surfaces", async () => {
+      const anchor = createTrackedSurfaceSplit(env, "focus-anchor", "right");
+      await sleep(1000);
+
+      focusSurface(backend, anchor);
+      await waitForFocusedSurface(backend, anchor, 10_000);
+
+      const childA = createTrackedSurface(env, "focus-child-a");
+      await sleep(FOCUS_TEST_SHELL_READY_DELAY_MS);
+      assert.equal(getFocusedSurface(backend), anchor);
+
+      const childB = createTrackedSurface(env, "focus-child-b");
+      await sleep(FOCUS_TEST_SHELL_READY_DELAY_MS);
+      assert.equal(getFocusedSurface(backend), anchor);
+
+      if (backend === "cmux") {
+        const paneA = getSurfacePane(backend, childA);
+        const paneB = getSurfacePane(backend, childB);
+        assert.ok(paneA, `Expected pane ref for ${childA}`);
+        assert.ok(paneB, `Expected pane ref for ${childB}`);
+        assert.equal(paneB, paneA);
+      }
+
+      const markerA = uniqueId();
+      const markerB = uniqueId();
+      sendCommand(childA, `echo "FOCUS_A_${markerA}"`);
+      sendCommand(childB, `echo "FOCUS_B_${markerB}"`);
+
+      await Promise.all([
+        waitForScreen(childA, new RegExp(`FOCUS_A_${markerA}`), 20_000, 50),
+        waitForScreen(childB, new RegExp(`FOCUS_B_${markerB}`), 20_000, 50),
+      ]);
+      assert.equal(getFocusedSurface(backend), anchor);
     });
 
     it("creates a surface, sends a command, reads output, and closes it", async () => {
@@ -158,16 +199,9 @@ for (const backend of backends) {
       const filePath = `/tmp/pi-mux-test-${marker}.txt`;
 
       sendCommand(surface, `echo "FILE_${marker}" > ${filePath} && echo "WRITTEN_${marker}"`);
-      await sleep(1500);
 
-      const screen = readScreen(surface, 50);
-      assert.ok(
-        screen.includes(`WRITTEN_${marker}`),
-        `Expected write confirmation. Got:\n${screen}`,
-      );
-
-      assert.ok(existsSync(filePath), `File should exist: ${filePath}`);
-      const content = readFileSync(filePath, "utf8");
+      await waitForScreen(surface, new RegExp(`WRITTEN_${marker}`), 10_000, 50);
+      const content = await waitForFile(filePath, 10_000, new RegExp(`FILE_${marker}`));
       assert.ok(content.includes(`FILE_${marker}`), `File content wrong. Got: ${content}`);
 
       // Clean up

--- a/test/test.ts
+++ b/test/test.ts
@@ -17,7 +17,16 @@ import {
   seedSubagentSessionFile,
 } from "../pi-extension/subagents/session.ts";
 
-import { shellEscape, isCmuxAvailable, isWezTermAvailable } from "../pi-extension/subagents/cmux.ts";
+import {
+  shellEscape,
+  isCmuxAvailable,
+  isWezTermAvailable,
+  parseCmuxFocusedSnapshot,
+  parseCmuxFocusedSnapshotFromJson,
+  parseCmuxJson,
+  parseCmuxPaneRefForSurface,
+  parseCmuxPaneRefForSurfaceFromJson,
+} from "../pi-extension/subagents/cmux.ts";
 import {
   advanceStatusState,
   capStatusLines,
@@ -1875,6 +1884,105 @@ describe("cmux.ts", () => {
       assert.ok(escaped.endsWith("'"));
       // Inside single quotes, everything is literal
       assert.ok(escaped.includes("$world"));
+    });
+  });
+
+  describe("parseCmuxFocusedSnapshot", () => {
+    it("parses focused surface and pane refs", () => {
+      assert.deepEqual(
+        parseCmuxFocusedSnapshot({ focused: { surface_ref: "surface:3", pane_ref: "pane:2" } }),
+        { surfaceRef: "surface:3", paneRef: "pane:2" },
+      );
+    });
+
+    it("does not fall back to caller refs", () => {
+      assert.equal(
+        parseCmuxFocusedSnapshot({ caller: { surface_ref: "surface:1", pane_ref: "pane:1" } }),
+        null,
+      );
+    });
+
+    it("returns null for malformed values", () => {
+      assert.equal(parseCmuxFocusedSnapshot(null), null);
+      assert.equal(parseCmuxFocusedSnapshot({ focused: {} }), null);
+    });
+  });
+
+  describe("parseCmuxJson", () => {
+    it("returns null for malformed JSON text", () => {
+      assert.equal(parseCmuxJson("not json"), null);
+    });
+
+    it("parses valid JSON text", () => {
+      assert.deepEqual(parseCmuxJson('{"ok":true}'), { ok: true });
+    });
+  });
+
+  describe("parseCmuxFocusedSnapshotFromJson", () => {
+    it("returns null for malformed JSON text", () => {
+      assert.equal(parseCmuxFocusedSnapshotFromJson("not json"), null);
+    });
+
+    it("returns null when focused is absent or not an object", () => {
+      assert.equal(
+        parseCmuxFocusedSnapshotFromJson('{"focused":null,"caller":{"surface_ref":"surface:1","pane_ref":"pane:1"}}'),
+        null,
+      );
+      assert.equal(
+        parseCmuxFocusedSnapshotFromJson('{"caller":{"surface_ref":"surface:1","pane_ref":"pane:1"}}'),
+        null,
+      );
+    });
+
+    it("parses focused refs without falling back to caller refs", () => {
+      assert.deepEqual(
+        parseCmuxFocusedSnapshotFromJson(
+          '{"caller":{"surface_ref":"surface:1","pane_ref":"pane:1"},"focused":{"surface_ref":"surface:2","pane_ref":"pane:3"}}',
+        ),
+        { surfaceRef: "surface:2", paneRef: "pane:3" },
+      );
+    });
+  });
+
+  describe("parseCmuxPaneRefForSurface", () => {
+    it("parses top-level pane refs for a surface", () => {
+      assert.equal(
+        parseCmuxPaneRefForSurface({ surface_ref: "surface:7", pane_ref: "pane:4" }, "surface:7"),
+        "pane:4",
+      );
+    });
+
+    it("parses caller pane refs for identify --surface output", () => {
+      assert.equal(
+        parseCmuxPaneRefForSurface(
+          { caller: { surface_ref: "surface:7", pane_ref: "pane:4" } },
+          "surface:7",
+        ),
+        "pane:4",
+      );
+    });
+
+    it("returns null when the surface does not match", () => {
+      assert.equal(
+        parseCmuxPaneRefForSurface({ surface_ref: "surface:8", pane_ref: "pane:4" }, "surface:7"),
+        null,
+      );
+    });
+  });
+
+  describe("parseCmuxPaneRefForSurfaceFromJson", () => {
+    it("returns null for malformed JSON text", () => {
+      assert.equal(parseCmuxPaneRefForSurfaceFromJson("not json", "surface:7"), null);
+    });
+
+    it("parses caller refs from cmux identify --surface JSON text", () => {
+      assert.equal(
+        parseCmuxPaneRefForSurfaceFromJson(
+          '{"caller":{"surface_ref":"surface:7","pane_ref":"pane:4"}}',
+          "surface:7",
+        ),
+        "pane:4",
+      );
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/HazAT/pi-interactive-subagents/issues/33.  Subagent launches are now focus-neutral for cmux and tmux: the user's focused pane before launch remains focused afterward, whether that's the orchestrator session or another pane.

For cmux, a `focused.*` snapshot from `cmux identify --json` is captured before each `new-split` or `new-surface --pane` and conditionally restored if cmux moved focus to a launch-touched surface.  For tmux, `split-window -d` replaces the previous selecting split, and the `select-pane -T` title step (which re-focused the child) is removed.  The integration runner is serialized with `--test-concurrency=1` because the new focus test asserts global mux state.

Summary of changes:
- cmux: add focus snapshot capture/restore around `new-split` and `new-surface --pane` creation paths, using `cmux identify --json` `focused.*` fields (never `caller.*`)
- cmux: anchor initial splits to `CMUX_SURFACE_ID` when available, separating placement from focus
- cmux: parse cmux JSON with non-throwing `JSON.parse` instead of regex section scanning; add `parseCmuxJson`, `parseCmuxFocusedSnapshot`, `parseCmuxCallerSnapshot` helpers
- cmux: track child surface, source surface, caller surface, and caller pane as launch-touched focus destinations for conditional restore
- tmux: use `split-window -d` for detached child creation; remove focus-changing `select-pane -T` title step
- harness: add `focusSurface`, `getFocusedSurface`, `getSurfacePane`, `waitForFocusedSurface`, `createTrackedSurfaceSplit` test helpers for cmux/tmux
- integration: add `keeps focus on the active surface while creating and targeting subagent surfaces` test covering initial split and reused-pane paths, with same-pane assertions for cmux
- integration: serialize test files with `--test-concurrency=1` in `package.json` to prevent global-focus contention between suites
- unit: add parser coverage for `parseCmuxFocusedSnapshot`, `parseCmuxFocusedSnapshotFromJson`, `parseCmuxJson`, `parseCmuxPaneRefForSurface`, `parseCmuxPaneRefForSurfaceFromJson`, including `focused:null` + caller-present regression

Testing:
- `npm test` - all passing
- `npm run test:integration` - all passing
- Manually e2e verified focus preservation: 3x while typing continuously and furiously into the in-focus orchestrator pane as one or more subagent panes are launched, and 3x while typing the same way but into an in-focus other, non-orchestrator pane