### PR TITLE
Fix subagent model fallback for unavailable agent defaults

### DIFF
--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -356,6 +356,15 @@ type ModelRegistryLike = Pick<ExtensionContext["modelRegistry"], "getAll"> & {
   getAvailable?: () => ModelRegistryModel[];
 };
 type CurrentModelLike = ExtensionContext["model"];
+interface ModelFallbackWarning {
+  requested: string;
+  used: string;
+  reason: "unavailable" | "registry-unavailable";
+}
+interface ModelResolution {
+  model?: string;
+  warning?: ModelFallbackWarning;
+}
 
 function currentModelReference(model: CurrentModelLike): string | undefined {
   return model ? `${model.provider}/${model.id}` : undefined;
@@ -449,22 +458,52 @@ function resolveEffectiveModel(
   agentDefs: AgentDefaults | null,
   ctx: { modelRegistry?: ModelRegistryLike; model?: CurrentModelLike },
 ): string | undefined {
+  return resolveEffectiveModelResolution(params, agentDefs, ctx).model;
+}
+
+function resolveEffectiveModelResolution(
+  params: Static<typeof SubagentParams>,
+  agentDefs: AgentDefaults | null,
+  ctx: { modelRegistry?: ModelRegistryLike; model?: CurrentModelLike },
+): ModelResolution {
   const requestedModel = params.model ?? agentDefs?.model;
-  if (!requestedModel) return undefined;
+  if (!requestedModel) return {};
 
   if (ctx.modelRegistry) {
-    return (
-      resolveAvailableModelReference(requestedModel, ctx.modelRegistry) ??
-      currentModelReference(ctx.model) ??
-      requestedModel
-    );
+    const availableModel = resolveAvailableModelReference(requestedModel, ctx.modelRegistry);
+    if (availableModel) return { model: availableModel };
+
+    const currentModel = currentModelReference(ctx.model);
+    if (currentModel) {
+      return {
+        model: currentModel,
+        warning: { requested: requestedModel, used: currentModel, reason: "unavailable" },
+      };
+    }
+
+    return { model: requestedModel };
   }
 
   if (params.model) {
-    return requestedModel;
+    return { model: requestedModel };
   }
 
-  return currentModelReference(ctx.model) ?? requestedModel;
+  const currentModel = currentModelReference(ctx.model);
+  if (currentModel) {
+    return {
+      model: currentModel,
+      warning: { requested: requestedModel, used: currentModel, reason: "registry-unavailable" },
+    };
+  }
+
+  return { model: requestedModel };
+}
+
+function formatModelFallbackWarning(warning: ModelFallbackWarning): string {
+  const reason = warning.reason === "registry-unavailable"
+    ? "the model registry was unavailable"
+    : "the requested model is not available in this environment";
+  return `Warning: subagent requested model "${warning.requested}", but ${reason}; using "${warning.used}" instead.`;
 }
 
 function loadAgentDefaults(agentName: string): AgentDefaults | null {
@@ -588,6 +627,7 @@ interface RunningSubagent {
   sessionFile: string;
   launchScriptFile?: string;
   activityFile?: string;
+  modelWarning?: ModelFallbackWarning;
   activity?: SubagentActivityState;
   activityRead?: {
     ok: boolean;
@@ -963,7 +1003,9 @@ export const __test__ = {
   resolveLaunchBehavior,
   resolveEffectiveInteractive,
   resolveEffectiveModel,
+  resolveEffectiveModelResolution,
   resolveAvailableModelReference,
+  formatModelFallbackWarning,
   modelReferenceExists,
   buildPiPromptArgs,
   formatWidgetRightLabel,
@@ -1005,9 +1047,10 @@ async function launchSubagent(
   const id = Math.random().toString(16).slice(2, 10);
 
   const agentDefs = params.agent ? loadAgentDefaults(params.agent) : null;
+  const modelResolution = resolveEffectiveModelResolution(params, agentDefs, ctx);
   const effectiveModel = agentDefs?.cli === "claude"
     ? (params.model ?? agentDefs?.model)
-    : resolveEffectiveModel(params, agentDefs, ctx);
+    : modelResolution.model;
   const effectiveTools = params.tools ?? agentDefs?.tools;
   const effectiveSkills = params.skills ?? agentDefs?.skills;
   const effectiveThinking = agentDefs?.thinking;
@@ -1280,6 +1323,7 @@ async function launchSubagent(
     sessionFile: subagentSessionFile,
     launchScriptFile,
     activityFile,
+    modelWarning: modelResolution.warning,
     interactive: effectiveInteractive,
     statusState: createStatusState({
       source: "pi",
@@ -1585,11 +1629,16 @@ export default function subagentsExtension(pi: ExtensionAPI) {
           });
 
         // Return immediately
+        const modelWarningText = running.modelWarning
+          ? `${formatModelFallbackWarning(running.modelWarning)}\n\n`
+          : "";
+
         return {
           content: [
             {
               type: "text",
               text:
+                modelWarningText +
                 `Sub-agent "${params.name}" launched and is now running in the background. ` +
                 `Do NOT generate or assume any results — you have no idea what the sub-agent will do or produce. ` +
                 `The results will be delivered to you automatically as a steer message when the sub-agent finishes. ` +
@@ -1603,6 +1652,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
             agent: params.agent,
             sessionFile: running.sessionFile,
             launchScriptFile: running.launchScriptFile,
+            ...(running.modelWarning ? { modelWarning: running.modelWarning } : {}),
             status: "started",
           },
         };

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -506,6 +506,26 @@ function formatModelFallbackWarning(warning: ModelFallbackWarning): string {
   return `Warning: subagent requested model "${warning.requested}", but ${reason}; using "${warning.used}" instead.`;
 }
 
+function notifyModelFallbackWarning(
+  pi: ExtensionAPI,
+  running: Pick<RunningSubagent, "name" | "agent" | "modelWarning">,
+) {
+  if (!running.modelWarning) return;
+  pi.sendMessage(
+    {
+      customType: "subagent_model_warning",
+      content: formatModelFallbackWarning(running.modelWarning),
+      display: true,
+      details: {
+        name: running.name,
+        agent: running.agent,
+        modelWarning: running.modelWarning,
+      },
+    },
+    { triggerTurn: true, deliverAs: "steer" },
+  );
+}
+
 function loadAgentDefaults(agentName: string): AgentDefaults | null {
   const configDir = getAgentConfigDir();
   const paths = [
@@ -1006,6 +1026,7 @@ export const __test__ = {
   resolveEffectiveModelResolution,
   resolveAvailableModelReference,
   formatModelFallbackWarning,
+  notifyModelFallbackWarning,
   modelReferenceExists,
   buildPiPromptArgs,
   formatWidgetRightLabel,
@@ -1560,6 +1581,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 
         // Launch the subagent (creates pane, sends command)
         const running = await launchSubagent(params, ctx);
+        notifyModelFallbackWarning(pi, running);
 
         // Create a separate AbortController for the watcher
         // (the tool's signal completes when we return)

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -351,6 +351,122 @@ function resolveEffectiveInteractive(
   return !(agentDefs?.autoExit ?? false);
 }
 
+type ModelRegistryModel = ReturnType<ExtensionContext["modelRegistry"]["getAll"]>[number];
+type ModelRegistryLike = Pick<ExtensionContext["modelRegistry"], "getAll"> & {
+  getAvailable?: () => ModelRegistryModel[];
+};
+type CurrentModelLike = ExtensionContext["model"];
+
+function currentModelReference(model: CurrentModelLike): string | undefined {
+  return model ? `${model.provider}/${model.id}` : undefined;
+}
+
+function availableModels(modelRegistry: ModelRegistryLike): ModelRegistryModel[] {
+  return modelRegistry.getAvailable?.() ?? modelRegistry.getAll();
+}
+
+function splitThinkingSuffix(modelReference: string): { base: string; suffix: string } {
+  const lastColon = modelReference.lastIndexOf(":");
+  if (lastColon === -1) return { base: modelReference, suffix: "" };
+  return {
+    base: modelReference.slice(0, lastColon),
+    suffix: modelReference.slice(lastColon),
+  };
+}
+
+function formatModelReference(model: ModelRegistryModel, suffix = ""): string {
+  return `${model.provider}/${model.id}${suffix}`;
+}
+
+function modelScore(model: ModelRegistryModel, query: string): number {
+  const id = model.id.toLowerCase();
+  const provider = model.provider.toLowerCase();
+  const name = String((model as { name?: unknown }).name ?? "").toLowerCase();
+  const full = `${provider}/${id}`;
+
+  if (id === query || full === query) return 100;
+  if (id.includes(query) || full.includes(query)) return 60 + (query.length / id.length) * 30;
+  if (name && name.includes(query)) return 40 + (query.length / name.length) * 20;
+
+  const parts = query.split(/[\s\-/]+/).filter(Boolean);
+  if (
+    parts.length > 0 &&
+    parts.every((part) => id.includes(part) || name.includes(part) || provider.includes(part))
+  ) {
+    return 20;
+  }
+
+  return 0;
+}
+
+function modelReferenceExists(modelReference: string, modelRegistry: ModelRegistryLike): boolean {
+  return resolveAvailableModelReference(modelReference, modelRegistry) != null;
+}
+
+function resolveAvailableModelReference(
+  modelReference: string,
+  modelRegistry: ModelRegistryLike,
+): string | undefined {
+  const models = availableModels(modelRegistry);
+  const requested = modelReference.trim();
+  if (!requested) return undefined;
+  const { base, suffix } = splitThinkingSuffix(requested);
+  const query = base.trim().toLowerCase();
+  if (!query) return undefined;
+
+  const exact = models.find(
+    (model) =>
+      `${model.provider}/${model.id}`.toLowerCase() === query ||
+      model.id.toLowerCase() === query,
+  );
+  if (exact) return formatModelReference(exact, suffix);
+
+  const slashIndex = base.indexOf("/");
+  if (slashIndex !== -1) {
+    const provider = base.slice(0, slashIndex).trim().toLowerCase();
+    const modelId = base.slice(slashIndex + 1).trim().toLowerCase();
+    const providerExact = models.find(
+      (model) => model.provider.toLowerCase() === provider && model.id.toLowerCase() === modelId,
+    );
+    if (providerExact) return formatModelReference(providerExact, suffix);
+  }
+
+  let bestMatch: ModelRegistryModel | undefined;
+  let bestScore = 0;
+  for (const model of models) {
+    const score = modelScore(model, query);
+    if (score > bestScore) {
+      bestScore = score;
+      bestMatch = model;
+    }
+  }
+
+  return bestMatch && bestScore >= 20 ? formatModelReference(bestMatch, suffix) : undefined;
+}
+
+function resolveEffectiveModel(
+  params: Static<typeof SubagentParams>,
+  agentDefs: AgentDefaults | null,
+  ctx: { modelRegistry?: ModelRegistryLike; model?: CurrentModelLike },
+): string | undefined {
+  const requestedModel = params.model ?? agentDefs?.model;
+  if (!requestedModel) return undefined;
+
+  if (ctx.modelRegistry) {
+    return (
+      resolveAvailableModelReference(requestedModel, ctx.modelRegistry) ??
+      currentModelReference(ctx.model) ??
+      requestedModel
+    );
+  }
+
+  if (params.model) {
+    return requestedModel;
+  }
+
+  return currentModelReference(ctx.model) ?? requestedModel;
+}
+
 function loadAgentDefaults(agentName: string): AgentDefaults | null {
   const configDir = getAgentConfigDir();
   const paths = [
@@ -846,6 +962,9 @@ export const __test__ = {
   resolveEffectiveSessionMode,
   resolveLaunchBehavior,
   resolveEffectiveInteractive,
+  resolveEffectiveModel,
+  resolveAvailableModelReference,
+  modelReferenceExists,
   buildPiPromptArgs,
   formatWidgetRightLabel,
   observeRunningSubagent,
@@ -874,14 +993,21 @@ function startWidgetRefresh() {
  */
 async function launchSubagent(
   params: typeof SubagentParams.static,
-  ctx: { sessionManager: { getSessionFile(): string | null; getSessionId(): string; getSessionDir(): string }; cwd: string },
+  ctx: {
+    sessionManager: { getSessionFile(): string | null; getSessionId(): string; getSessionDir(): string };
+    cwd: string;
+    modelRegistry?: ModelRegistryLike;
+    model?: CurrentModelLike;
+  },
   options?: { surface?: string },
 ): Promise<RunningSubagent> {
   const startTime = Date.now();
   const id = Math.random().toString(16).slice(2, 10);
 
   const agentDefs = params.agent ? loadAgentDefaults(params.agent) : null;
-  const effectiveModel = params.model ?? agentDefs?.model;
+  const effectiveModel = agentDefs?.cli === "claude"
+    ? (params.model ?? agentDefs?.model)
+    : resolveEffectiveModel(params, agentDefs, ctx);
   const effectiveTools = params.tools ?? agentDefs?.tools;
   const effectiveSkills = params.skills ?? agentDefs?.skills;
   const effectiveThinking = agentDefs?.thinking;

--- a/test/test.ts
+++ b/test/test.ts
@@ -917,6 +917,80 @@ describe("subagent discovery", () => {
     );
   });
 
+  it("resolves agent models against the available registry before falling back", () => {
+    const modelRegistry = {
+      getAll: () => [
+        { provider: "anthropic", id: "claude-haiku-4-5", name: "Claude Haiku 4.5" },
+        { provider: "anthropic", id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
+        { provider: "openai-codex", id: "gpt-5.5", name: "GPT 5.5" },
+      ],
+      getAvailable: () => [
+        { provider: "anthropic", id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
+        { provider: "openai-codex", id: "gpt-5.5", name: "GPT 5.5" },
+      ],
+    };
+    const mainModel = { provider: "openai-codex", id: "gpt-5.5" };
+
+    const cases: Array<{ requested: string; expected: string }> = [
+      { requested: "anthropic/claude-sonnet-4-5", expected: "anthropic/claude-sonnet-4-5" },
+      { requested: "anthropic/claude-sonnet-4-5:medium", expected: "anthropic/claude-sonnet-4-5:medium" },
+      { requested: "gpt", expected: "openai-codex/gpt-5.5" },
+      { requested: "anthropic/claude-haiku-4-5", expected: "openai-codex/gpt-5.5" },
+      { requested: "anthropic/claude-does-not-exist", expected: "openai-codex/gpt-5.5" },
+    ];
+
+    for (const { requested, expected } of cases) {
+      assert.equal(
+        testApi.resolveEffectiveModel(
+          { name: "A", task: "T" },
+          { model: requested },
+          { modelRegistry, model: mainModel },
+        ),
+        expected,
+        requested,
+      );
+    }
+  });
+
+  it("uses the main session model for agent defaults when the registry is unavailable", () => {
+    const mainModel = { provider: "openai-codex", id: "gpt-5.5" };
+
+    assert.equal(
+      testApi.resolveEffectiveModel(
+        { name: "A", task: "T" },
+        { model: "anthropic/claude-haiku-4-5" },
+        { model: mainModel },
+      ),
+      "openai-codex/gpt-5.5",
+    );
+  });
+
+  it("preserves an explicit model override when the registry is unavailable", () => {
+    const mainModel = { provider: "openai-codex", id: "gpt-5.5" };
+
+    assert.equal(
+      testApi.resolveEffectiveModel(
+        { name: "A", task: "T", model: "anthropic/claude-haiku-4-5" },
+        { model: "openai-codex/gpt-5.5" },
+        { model: mainModel },
+      ),
+      "anthropic/claude-haiku-4-5",
+    );
+  });
+
+  it("resolves fuzzy model names against available models", () => {
+    const modelRegistry = {
+      getAll: () => [
+        { provider: "anthropic", id: "claude-haiku-4-5", name: "Claude Haiku 4.5" },
+        { provider: "openai-codex", id: "gpt-5.5", name: "GPT 5.5" },
+      ],
+      getAvailable: () => [{ provider: "openai-codex", id: "gpt-5.5", name: "GPT 5.5" }],
+    };
+
+    assert.equal(testApi.resolveAvailableModelReference("gpt", modelRegistry), "openai-codex/gpt-5.5");
+    assert.equal(testApi.modelReferenceExists("anthropic/claude-haiku-4-5", modelRegistry), false);
+  });
+
   it("bundled scout/worker/reviewer agents resolve as non-interactive; planner resolves as interactive", () => {
     for (const name of ["scout", "worker", "reviewer"]) {
       const defs = testApi.loadAgentDefaults(name);

--- a/test/test.ts
+++ b/test/test.ts
@@ -1006,6 +1006,28 @@ describe("subagent discovery", () => {
     assert.equal(testApi.modelReferenceExists("anthropic/claude-haiku-4-5", modelRegistry), false);
   });
 
+  it("sends a visible steer message for model fallback warnings", () => {
+    const { api, sentMessages } = createMockExtensionApi();
+    const warning = {
+      requested: "anthropic/claude-haiku-4-5",
+      used: "openai-codex/gpt-5.5",
+      reason: "unavailable" as const,
+    };
+
+    testApi.notifyModelFallbackWarning(api, {
+      name: "Scout",
+      agent: "scout",
+      modelWarning: warning,
+    });
+
+    assert.equal(sentMessages.length, 1);
+    assert.equal(sentMessages[0].message.customType, "subagent_model_warning");
+    assert.equal(sentMessages[0].message.display, true);
+    assert.equal(sentMessages[0].message.details.modelWarning, warning);
+    assert.deepEqual(sentMessages[0].options, { triggerTurn: true, deliverAs: "steer" });
+    assert.match(sentMessages[0].message.content, /requested model "anthropic\/claude-haiku-4-5"/);
+  });
+
   it("bundled scout/worker/reviewer agents resolve as non-interactive; planner resolves as interactive", () => {
     for (const name of ["scout", "worker", "reviewer"]) {
       const defs = testApi.loadAgentDefaults(name);

--- a/test/test.ts
+++ b/test/test.ts
@@ -950,18 +950,33 @@ describe("subagent discovery", () => {
         requested,
       );
     }
+
+    assert.deepEqual(
+      testApi.resolveEffectiveModelResolution(
+        { name: "A", task: "T" },
+        { model: "anthropic/claude-haiku-4-5" },
+        { modelRegistry, model: mainModel },
+      ).warning,
+      {
+        requested: "anthropic/claude-haiku-4-5",
+        used: "openai-codex/gpt-5.5",
+        reason: "unavailable",
+      },
+    );
   });
 
   it("uses the main session model for agent defaults when the registry is unavailable", () => {
     const mainModel = { provider: "openai-codex", id: "gpt-5.5" };
+    const resolution = testApi.resolveEffectiveModelResolution(
+      { name: "A", task: "T" },
+      { model: "anthropic/claude-haiku-4-5" },
+      { model: mainModel },
+    );
 
+    assert.equal(resolution.model, "openai-codex/gpt-5.5");
     assert.equal(
-      testApi.resolveEffectiveModel(
-        { name: "A", task: "T" },
-        { model: "anthropic/claude-haiku-4-5" },
-        { model: mainModel },
-      ),
-      "openai-codex/gpt-5.5",
+      testApi.formatModelFallbackWarning(resolution.warning),
+      'Warning: subagent requested model "anthropic/claude-haiku-4-5", but the model registry was unavailable; using "openai-codex/gpt-5.5" instead.',
     );
   });
 


### PR DESCRIPTION
## Summary

  This fixes subagent launches when an agent’s configured default model is not available in the current Pi environment.

  Subagents now resolve agent model defaults against currently available models, fall back to the main session model when needed, and visibly warn the parent
  agent when a fallback happens.

  ## Changes

  - Prefer modelRegistry.getAvailable() over getAll() when validating agent models.
  - Fall back to the current main-session model when an agent default model is unavailable.
  - Preserve explicit params.model overrides when the registry is unavailable.
  - Support fuzzy model matching and preserve inline thinking suffixes such as :medium.
  - Add visible subagent_model_warning steer messages when fallback occurs.
  - Include structured fallback details in details.modelWarning.


<img width="1444" height="1082" alt="image" src="https://github.com/user-attachments/assets/5c543643-1ae0-41de-89b4-9cbafd22ad99" />