### PR TITLE
Fix auto-exit behavior for resumed subagents

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,14 @@ This is a turn-level interrupt, not a method for forcibly terminating a subagent
 
 The `caller_ping` tool lets a subagent request help from its parent agent. When called, the child session **exits** and the parent receives a notification with the help message. The parent can then **resume** the child session with a response using `subagent_resume`.
 
-**Parameters:**
+**`caller_ping` parameters:**
 - `message` (required): What you need help with
+
+**`subagent_resume` parameters:**
+- `sessionPath` (required): Path to the child session `.jsonl` file
+- `name` (optional): Display name for the resumed pane (defaults to `Resume`)
+- `message` (optional): Follow-up prompt to send after resuming
+- `autoExit` (optional): Whether the resumed session should auto-exit after its next response. Defaults to `true` for autonomous follow-up work; set `false` when resuming for an interactive handoff.
 
 **Interaction flow:**
 1. Child calls `caller_ping({ message: "Not sure which schema to use" })`

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -837,6 +837,11 @@ function startStatusRefresh(pi: ExtensionAPI) {
   (globalThis as any)[STATUS_INTERVAL_KEY] = statusInterval;
 }
 
+function resolveResumeLaunchBehavior(params: { autoExit?: boolean }): { autoExit: boolean; interactive: boolean } {
+  const autoExit = params.autoExit ?? true;
+  return { autoExit, interactive: !autoExit };
+}
+
 export const __test__ = {
   borderLine,
   getShellReadyDelayMs,
@@ -854,6 +859,7 @@ export const __test__ = {
   requestSubagentInterrupt,
   handleSubagentInterrupt,
   resolveResultPresentation,
+  resolveResumeLaunchBehavior,
   runningSubagents,
 };
 
@@ -1671,6 +1677,12 @@ export default function subagentsExtension(pi: ExtensionAPI) {
             description: "Optional message to send after resuming (e.g. follow-up instructions)",
           }),
         ),
+        autoExit: Type.Optional(
+          Type.Boolean({
+            description:
+              "Whether the resumed session should automatically exit after completing its response. Defaults to true for autonomous follow-up work; set false for interactive resumed sessions.",
+          }),
+        ),
       }),
 
       renderCall(args, theme) {
@@ -1704,6 +1716,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 
       async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
         const name = params.name ?? "Resume";
+        const { autoExit, interactive } = resolveResumeLaunchBehavior(params);
         const startTime = Date.now();
         const id = Math.random().toString(16).slice(2, 10);
 
@@ -1768,6 +1781,9 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         resumeEnvParts.push(`PI_SUBAGENT_SESSION=${shellEscape(params.sessionPath)}`);
         resumeEnvParts.push(`PI_SUBAGENT_ID=${shellEscape(id)}`);
         resumeEnvParts.push(`PI_SUBAGENT_ACTIVITY_FILE=${shellEscape(activityFile)}`);
+        if (autoExit) {
+          resumeEnvParts.push(`PI_SUBAGENT_AUTO_EXIT=1`);
+        }
         const resumeEnvPrefix = resumeEnvParts.join(" ") + " ";
 
         const command = `${resumeEnvPrefix}${parts.join(" ")}; echo '__SUBAGENT_DONE_'$?'__'`;
@@ -1802,7 +1818,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
           sessionFile: params.sessionPath,
           launchScriptFile,
           activityFile,
-          interactive: true,
+          interactive,
           statusState: createStatusState({
             source: "pi",
             startTimeMs: startTime,

--- a/test/test.ts
+++ b/test/test.ts
@@ -1180,6 +1180,19 @@ describe("commands", () => {
 });
 
 describe("tool registration", () => {
+  it("defaults resumed subagents to auto-exit and non-interactive tracking", () => {
+    const testApi = (subagentsModule as any).__test__;
+
+    assert.deepEqual(testApi.resolveResumeLaunchBehavior({}), {
+      autoExit: true,
+      interactive: false,
+    });
+    assert.deepEqual(testApi.resolveResumeLaunchBehavior({ autoExit: false }), {
+      autoExit: false,
+      interactive: true,
+    });
+  });
+
   it("expands spawning false to deny subagent interruption", () => {
     const testApi = (subagentsModule as any).__test__;
     const denied = testApi.resolveDenyTools({ spawning: false });
@@ -1208,6 +1221,18 @@ describe("tool registration", () => {
     const output = rendered.render(80).join("\n");
 
     assert.match(output, /\(unnamed\)/);
+  });
+
+  it("registers subagent_resume with an autoExit override", () => {
+    const { api, registeredTools } = createMockExtensionApi();
+    (subagentsModule as any).default(api);
+
+    const resumeTool = registeredTools.find((tool) => tool.name === "subagent_resume");
+    assert.ok(resumeTool, "expected subagent_resume tool to be registered");
+
+    const autoExitSchema = resumeTool.parameters.properties.autoExit;
+    assert.equal(autoExitSchema.type, "boolean");
+    assert.match(autoExitSchema.description, /Defaults to true/);
   });
 });
 


### PR DESCRIPTION
## Problem
When using subagents as part of autonomous workflows, I've been running into the issue that resumed subagents just stop and don't auto-exit like normal agents.

## Summary
- Preserve autonomous auto-exit semantics when resuming subagents.
- Add an optional `autoExit` parameter to `subagent_resume`, defaulting to `true` for asynchronous follow-up work.
- Set `PI_SUBAGENT_AUTO_EXIT=1` for auto-exiting resumes and track running state with `interactive: !autoExit`.
- Document `subagent_resume` parameters and cover the new default/override behavior in tests.

## Verification
- `npm test` currently fails under Node because Node cannot load `.ts` test files directly: `ERR_UNKNOWN_FILE_EXTENSION`.
- `bun test ./test/test.ts` passes: 90 pass, 0 fail.
- `git diff --check` passes.