### PR TITLE
fix(subagents): preserve child control tools with restricted tools

### DIFF
--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -636,6 +636,32 @@ function updateWidget() {
  * first positional message so that /skill: args land in messages[1..] and arrive
  * as standalone prompts in the child session.
  */
+const SUBAGENT_CONTROL_TOOLS = ["caller_ping", "subagent_done"] as const;
+
+/**
+ * Build the child --tools allowlist.
+ *
+ * Pi 0.70+ applies --tools to built-in, extension, and custom tools. If a
+ * subagent definition restricts tools to e.g. "read,bash,write", the child
+ * control tools from subagent-done.ts would otherwise be hidden, leaving a
+ * manually resumed or user-touched subagent unable to call subagent_done.
+ */
+function buildSubagentToolAllowlist(effectiveTools?: string): string | null {
+  const requested = (effectiveTools ?? "")
+    .split(",")
+    .map((tool) => tool.trim())
+    .filter(Boolean);
+
+  if (requested.length === 0) return null;
+
+  const allow = new Set(requested);
+  for (const tool of SUBAGENT_CONTROL_TOOLS) {
+    allow.add(tool);
+  }
+
+  return [...allow].join(",");
+}
+
 function buildPiPromptArgs(params: {
   effectiveSkills?: string;
   taskDelivery: "direct" | "artifact";
@@ -846,6 +872,7 @@ export const __test__ = {
   resolveEffectiveSessionMode,
   resolveLaunchBehavior,
   resolveEffectiveInteractive,
+  buildSubagentToolAllowlist,
   buildPiPromptArgs,
   formatWidgetRightLabel,
   observeRunningSubagent,
@@ -1053,15 +1080,9 @@ async function launchSubagent(
     parts.push(flag, shellEscape(syspromptPath));
   }
 
-  if (effectiveTools) {
-    const BUILTIN_TOOLS = new Set(["read", "bash", "edit", "write", "grep", "find", "ls"]);
-    const builtins = effectiveTools
-      .split(",")
-      .map((t) => t.trim())
-      .filter((t) => BUILTIN_TOOLS.has(t));
-    if (builtins.length > 0) {
-      parts.push("--tools", shellEscape(builtins.join(",")));
-    }
+  const toolAllowlist = buildSubagentToolAllowlist(effectiveTools);
+  if (toolAllowlist) {
+    parts.push("--tools", shellEscape(toolAllowlist));
   }
 
   // Build env prefix: denied tools + subagent identity + config dir propagation

--- a/test/test.ts
+++ b/test/test.ts
@@ -1009,6 +1009,18 @@ describe("subagent discovery", () => {
     );
   });
 
+  it("buildSubagentToolAllowlist preserves requested tools and adds child control tools", () => {
+    assert.equal(
+      testApi.buildSubagentToolAllowlist("read,bash,web_search"),
+      "read,bash,web_search,caller_ping,subagent_done",
+    );
+  });
+
+  it("buildSubagentToolAllowlist returns null without an explicit tool restriction", () => {
+    assert.equal(testApi.buildSubagentToolAllowlist(undefined), null);
+    assert.equal(testApi.buildSubagentToolAllowlist(""), null);
+  });
+
   it("buildPiPromptArgs inserts separator for artifact-backed launches with skills", () => {
     assert.deepEqual(
       testApi.buildPiPromptArgs({ effectiveSkills: "review,lint", taskDelivery: "artifact", taskArg: "@artifact.md" }),


### PR DESCRIPTION
## Summary

Pi 0.70+ applies `--tools` to built-in, extension, and custom tools. If a subagent definition restricts tools, for example `tools: read,bash,write`, the child currently loses the control tools registered by `subagent-done.ts`.

This keeps the requested child tool allowlist, but always adds:

- `subagent_done`
- `caller_ping`

That way restricted autonomous subagents can still finish or ask the parent for help.

## Repro

1. Define an auto-exit agent with `tools: read,bash,write`.
2. Spawn it.
3. The child is launched with `--tools read,bash,write`.
4. Extension tools from `subagent-done.ts` are hidden, so a user-touched or manually resumed child cannot call `subagent_done`.

## Test plan

- Added unit coverage for the child tool allowlist.
- Ran `bun build` for `pi-extension/subagents/index.ts` and `pi-extension/subagents/subagent-done.ts`.
- Ran `bun build` for `test/test.ts`.

I did not include any package-lock changes.
