### PR TITLE
fix(subagents): auto-exit after user-driven normal completion

### DIFF
--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -14,11 +14,12 @@ export function shouldMarkUserTookOver(agentStarted: boolean): boolean {
 }
 
 export function shouldAutoExitOnAgentEnd(
-  userTookOver: boolean,
+  _userTookOver: boolean,
   messages: any[] | undefined,
 ): boolean {
-  if (userTookOver) return false;
-
+  // Manual input should not strand an auto-exit subagent. If the latest agent
+  // turn completed normally, close the session. Escape/abort still leaves it
+  // open for inspection or another prompt.
   if (messages) {
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i];
@@ -146,9 +147,8 @@ export default function (pi: ExtensionAPI) {
 
     recorder.agentEndWaiting();
     if (autoExit) {
-      // User sent input after the agent had started, or the run was interrupted
-      // with Escape. Reset takeover so auto-exit can re-engage on the next
-      // normal completion cycle.
+      // Reset any recorded manual input marker. Auto-exit is decided by whether
+      // the latest agent turn completed normally, not by who initiated it.
       userTookOver = false;
     }
   });

--- a/test/test.ts
+++ b/test/test.ts
@@ -1151,9 +1151,9 @@ describe("subagent-done.ts", () => {
       assert.equal(shouldAutoExitOnAgentEnd(false, messages), true);
     });
 
-    it("stays open after user takeover for that cycle", () => {
+    it("auto-exits after normal completion even when the user sent the prompt", () => {
       const messages = [{ role: "assistant", stopReason: "stop" }];
-      assert.equal(shouldAutoExitOnAgentEnd(true, messages), false);
+      assert.equal(shouldAutoExitOnAgentEnd(true, messages), true);
     });
 
     it("stays open after Escape aborts the run", () => {


### PR DESCRIPTION
## Summary

This changes auto-exit subagents so manual user input does not permanently strand the pane.

Before this change, any user input after the agent started set `userTookOver`, and a later normal assistant completion would stay open instead of exiting. That is surprising for agents with `auto-exit: true`, especially when the user simply tells the child "you are done, exit".

After this change:

- normal assistant completion exits for `auto-exit: true`
- Escape/aborted turns still stay open for inspection or another prompt

I split this from the control-tool allowlist fix because it is a behavior change and may be easier to review independently.

## Test plan

- Updated unit coverage for `shouldAutoExitOnAgentEnd`.
- Ran `bun build` for `pi-extension/subagents/index.ts` and `pi-extension/subagents/subagent-done.ts`.
- Ran `bun build` for `test/test.ts`.

I did not include any package-lock changes.
