### PR TITLE
feat(subagents): add dismiss tool for stale running entries

### DIFF
--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -159,6 +159,7 @@ interface ListedAgentDefinition extends AgentDefinition {
 const SPAWNING_TOOLS = new Set([
   "subagent",
   "subagent_interrupt",
+  "subagent_dismiss",
   "subagents_list",
   "subagent_resume",
 ]);
@@ -489,6 +490,12 @@ interface RunningSubagent {
    * subagent's pane (e.g. planner).
    */
   interactive: boolean;
+  /**
+   * Set when the parent intentionally forgets this run without waiting for a
+   * normal child exit. Used for panes killed outside the lifecycle or stale
+   * waiting/stalled widget entries.
+   */
+  dismissed?: boolean;
 }
 
 /** All currently running subagents, keyed by id. */
@@ -740,6 +747,55 @@ function requestSubagentInterrupt(
   }
 }
 
+function handleSubagentDismiss(
+  params: { id?: string; name?: string; closePane?: boolean },
+  closeSubagentSurface: (surface: string) => void = closeSurface,
+) {
+  const resolved = resolveInterruptTarget(params);
+  if ("error" in resolved) {
+    return {
+      content: [{ type: "text" as const, text: resolved.error }],
+      details: { error: resolved.error },
+    };
+  }
+
+  const running = resolved.running;
+  running.dismissed = true;
+  runningSubagents.delete(running.id);
+  running.abortController?.abort();
+
+  let closeError: string | undefined;
+  if (params.closePane) {
+    try {
+      closeSubagentSurface(running.surface);
+    } catch (error: any) {
+      closeError = error?.message ?? String(error);
+    }
+  }
+
+  updateWidget();
+
+  const closeText = params.closePane
+    ? closeError
+      ? ` Tried to close its pane, but that failed: ${closeError}`
+      : " Its pane was also closed."
+    : " Its pane was left alone.";
+
+  return {
+    content: [{
+      type: "text" as const,
+      text: `Dismissed subagent "${running.name}" from status tracking.${closeText}`,
+    }],
+    details: {
+      id: running.id,
+      name: running.name,
+      status: "dismissed",
+      closePane: !!params.closePane,
+      ...(closeError ? { closeError } : {}),
+    },
+  };
+}
+
 function handleSubagentInterrupt(
   params: { id?: string; name?: string },
   sendEscapeKey: (surface: string) => void = sendEscape,
@@ -852,6 +908,7 @@ export const __test__ = {
   resolveDenyTools,
   resolveInterruptTarget,
   requestSubagentInterrupt,
+  handleSubagentDismiss,
   handleSubagentInterrupt,
   resolveResultPresentation,
   runningSubagents,
@@ -1274,6 +1331,19 @@ async function watchSubagent(
       ping: result.ping,
     };
   } catch (err: any) {
+    if (running.dismissed) {
+      runningSubagents.delete(running.id);
+      return {
+        name,
+        task,
+        summary: "Subagent dismissed.",
+        exitCode: 0,
+        elapsed: Math.floor((Date.now() - startTime) / 1000),
+        error: "dismissed",
+        sessionFile,
+      };
+    }
+
     try {
       closeSurface(surface);
     } catch {}
@@ -1404,6 +1474,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         watchSubagent(running, watcherAbort.signal)
           .then((result) => {
             updateWidget(); // reflect removal from Map immediately
+            if (running.dismissed) return;
 
             if (result.ping) {
               // Subagent is requesting help — steer a ping message with session path for resume
@@ -1580,6 +1651,63 @@ export default function subagentsExtension(pi: ExtensionAPI) {
               " " +
               theme.fg("toolTitle", theme.bold(details.name ?? details.id ?? "subagent")) +
               theme.fg("dim", " — interrupt requested"),
+            0,
+            0,
+          );
+        }
+
+        const text = typeof result.content[0]?.text === "string" ? result.content[0].text : "";
+        return new Text(theme.fg("dim", text), 0, 0);
+      },
+    });
+
+  // ── subagent_dismiss tool ──
+  if (shouldRegister("subagent_dismiss"))
+    pi.registerTool({
+      name: "subagent_dismiss",
+      label: "Dismiss Subagent",
+      description:
+        "Remove a running subagent from parent status tracking without waiting for a normal child exit. " +
+        "Use when a child pane was killed externally, got stuck waiting, or otherwise cannot report completion. " +
+        "Optionally also close the pane. This does not emit a subagent_result.",
+      promptSnippet:
+        "Remove a running subagent from parent status tracking without waiting for a normal child exit. " +
+        "Use when a child pane was killed externally, got stuck waiting, or otherwise cannot report completion. " +
+        "Optionally also close the pane. This does not emit a subagent_result.",
+      parameters: Type.Object({
+        id: Type.Optional(Type.String({ description: "Exact running subagent id" })),
+        name: Type.Optional(Type.String({ description: "Exact running subagent display name" })),
+        closePane: Type.Optional(Type.Boolean({
+          description: "Also close the subagent pane/tab. Defaults to false.",
+        })),
+      }),
+
+      async execute(_toolCallId, params) {
+        return handleSubagentDismiss(params);
+      },
+
+      renderCall(args, theme) {
+        const target = args.id ? `${args.id}` : args.name ?? "(unknown)";
+        const closeHint = args.closePane ? theme.fg("dim", " + close pane") : "";
+        return new Text(
+          theme.fg("accent", "▸") +
+            " " +
+            theme.fg("toolTitle", theme.bold(target)) +
+            theme.fg("dim", " — dismiss") +
+            closeHint,
+          0,
+          0,
+        );
+      },
+
+      renderResult(result, _opts, theme) {
+        const details = result.details as any;
+        if (details?.status === "dismissed") {
+          return new Text(
+            theme.fg("accent", "▸") +
+              " " +
+              theme.fg("toolTitle", theme.bold(details.name ?? details.id ?? "subagent")) +
+              theme.fg("dim", " — dismissed"),
             0,
             0,
           );
@@ -1819,6 +1947,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         watchSubagent(running, watcherAbort.signal)
           .then((result) => {
             updateWidget();
+            if (running.dismissed) return;
 
             if (result.ping) {
               const sessionRef = `\n\nSession: ${params.sessionPath}\nResume: pi --session ${params.sessionPath}`;

--- a/test/test.ts
+++ b/test/test.ts
@@ -1406,6 +1406,14 @@ describe("subagent interruption", () => {
     assert.equal(registeredTools.some((tool) => tool.name === "subagent_interrupt"), true);
   });
 
+  it("registers subagent_dismiss in the main session extension", () => {
+    const { api, registeredTools } = createMockExtensionApi();
+
+    (subagentsModule as any).default(api);
+
+    assert.equal(registeredTools.some((tool) => tool.name === "subagent_dismiss"), true);
+  });
+
   it("resolves interrupt targets by exact id and reports name ambiguity", () => {
     const testApi = (subagentsModule as any).__test__;
     const runningMap = testApi.runningSubagents as Map<string, any>;
@@ -1421,6 +1429,62 @@ describe("subagent interruption", () => {
 
       const ambiguous = testApi.resolveInterruptTarget({ name: "Worker" });
       assert.match(ambiguous.error, /Ambiguous subagent name/);
+    } finally {
+      runningMap.clear();
+    }
+  });
+
+  it("dismisses a running subagent without closing its pane by default", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const runningMap = testApi.runningSubagents as Map<string, any>;
+    let aborted = false;
+    const closedSurfaces: string[] = [];
+    runningMap.clear();
+
+    try {
+      runningMap.set("a1", makeRunning({
+        abortController: { abort() { aborted = true; } },
+      }));
+
+      const result = testApi.handleSubagentDismiss({ id: "a1" }, (surface: string) => {
+        closedSurfaces.push(surface);
+      });
+
+      assert.equal(aborted, true);
+      assert.equal(runningMap.has("a1"), false);
+      assert.deepEqual(closedSurfaces, []);
+      assert.match(result.content[0].text, /Dismissed subagent "Worker"/);
+      assert.deepEqual(result.details, {
+        id: "a1",
+        name: "Worker",
+        status: "dismissed",
+        closePane: false,
+      });
+    } finally {
+      runningMap.clear();
+    }
+  });
+
+  it("can dismiss a running subagent and close its pane", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const runningMap = testApi.runningSubagents as Map<string, any>;
+    let aborted = false;
+    const closedSurfaces: string[] = [];
+    runningMap.clear();
+
+    try {
+      runningMap.set("a1", makeRunning({
+        abortController: { abort() { aborted = true; } },
+      }));
+
+      const result = testApi.handleSubagentDismiss({ name: "Worker", closePane: true }, (surface: string) => {
+        closedSurfaces.push(surface);
+      });
+
+      assert.equal(aborted, true);
+      assert.equal(runningMap.has("a1"), false);
+      assert.deepEqual(closedSurfaces, ["pane-1"]);
+      assert.equal(result.details.closePane, true);
     } finally {
       runningMap.clear();
     }


### PR DESCRIPTION
## Summary

Adds a `subagent_dismiss` tool for cleaning up stale subagent status entries from the parent session.

This covers cases where the child pane/session is killed outside the normal lifecycle, or a child gets stuck in a non-standard waiting/stalled state and never produces the normal sentinel/result. Today the widget can keep showing that child forever, with no parent-side way to forget it.

The new tool:

- removes the selected running subagent from `runningSubagents`
- aborts its watcher so no later `subagent_result` is emitted for the dismissed entry
- updates the widget immediately
- optionally closes the pane via `closePane: true`

I also added `subagent_dismiss` to the `spawning: false` denied tool set so child agents do not get parent-side subagent management tools.

## Example

```ts
subagent_dismiss({ name: "Worker" })
subagent_dismiss({ id: "abcd1234", closePane: true })
```

## Test plan

- Added unit coverage for tool registration.
- Added unit coverage for dismissing with and without closing the pane.
- Ran `bun build` for `pi-extension/subagents/index.ts` and `pi-extension/subagents/subagent-done.ts`.
- Ran `bun build` for `test/test.ts`.

No package-lock changes included.
