### PR TITLE
fix(zellij): use available screen space for subagent panes

### DIFF
--- a/pi-extension/subagents/cmux.ts
+++ b/pi-extension/subagents/cmux.ts
@@ -1,6 +1,6 @@
 import { execSync, execFile, execFileSync, spawnSync } from "node:child_process";
 import { promisify } from "node:util";
-import { existsSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync, mkdirSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 
@@ -201,6 +201,331 @@ async function zellijActionAsync(args: string[], surface?: string): Promise<stri
 
 /** Tracked subagent pane for cmux — reused across subagent launches. */
 let cmuxSubagentPane: string | null = null;
+
+// Mirrors Zellij 0.44.x tab minimums, used to predict which pane Zellij itself
+// will choose for a directionless split.
+const ZELLIJ_MIN_TERMINAL_WIDTH = 5;
+const ZELLIJ_MIN_TERMINAL_HEIGHT = 5;
+const ZELLIJ_CURSOR_HEIGHT_WIDTH_RATIO = 4;
+
+// Pi subagents need more usable space than Zellij's internal minimum. These can
+// be tuned per session without another code change.
+const DEFAULT_ZELLIJ_SUBAGENT_MIN_COLUMNS = 50;
+const DEFAULT_ZELLIJ_SUBAGENT_MIN_ROWS = 10;
+
+export interface ZellijPaneSnapshot {
+  id: number;
+  is_plugin?: boolean;
+  is_floating?: boolean;
+  is_selectable?: boolean;
+  exited?: boolean;
+  pane_rows?: number;
+  pane_columns?: number;
+  tab_id?: number;
+  is_focused?: boolean;
+}
+
+export type ZellijSplitDirection = "down" | "right";
+
+export type ZellijPlacementPlan =
+  | {
+      mode: "split";
+      anchorPaneId: number;
+      targetPaneId: number;
+      tabId: number;
+      splitDirection: ZellijSplitDirection;
+    }
+  | { mode: "stack"; anchorPaneId: number; targetPaneId: number; tabId: number };
+
+function paneArea(pane: ZellijPaneSnapshot): number {
+  return (pane.pane_rows ?? 0) * (pane.pane_columns ?? 0);
+}
+
+function isUsableZellijTiledPane(pane: ZellijPaneSnapshot): boolean {
+  return (
+    !pane.is_plugin &&
+    !pane.is_floating &&
+    pane.is_selectable !== false &&
+    !pane.exited &&
+    typeof pane.pane_rows === "number" &&
+    typeof pane.pane_columns === "number"
+  );
+}
+
+export function predictZellijSplitDirection(pane: ZellijPaneSnapshot): ZellijSplitDirection | null {
+  const columns = pane.pane_columns ?? 0;
+  const rows = pane.pane_rows ?? 0;
+  if (columns < ZELLIJ_MIN_TERMINAL_WIDTH || rows < ZELLIJ_MIN_TERMINAL_HEIGHT) return null;
+
+  if (
+    rows * ZELLIJ_CURSOR_HEIGHT_WIDTH_RATIO > columns &&
+    rows > ZELLIJ_MIN_TERMINAL_HEIGHT * 2
+  ) {
+    return "down";
+  }
+
+  if (columns > ZELLIJ_MIN_TERMINAL_WIDTH * 2) {
+    return "right";
+  }
+
+  return null;
+}
+
+export function canSplitZellijPane(
+  pane: ZellijPaneSnapshot,
+  minColumns = ZELLIJ_MIN_TERMINAL_WIDTH,
+  minRows = ZELLIJ_MIN_TERMINAL_HEIGHT,
+): boolean {
+  const columns = pane.pane_columns ?? 0;
+  const rows = pane.pane_rows ?? 0;
+  const direction = predictZellijSplitDirection(pane);
+  if (!direction) return false;
+
+  if (direction === "down") {
+    return columns >= minColumns && Math.floor(rows / 2) >= minRows;
+  }
+
+  return rows >= minRows && Math.floor(columns / 2) >= minColumns;
+}
+
+function zellijTabPanesForParent(
+  panes: ZellijPaneSnapshot[],
+  parentPaneId: number,
+): { parentPane: ZellijPaneSnapshot; tabPanes: ZellijPaneSnapshot[] } | null {
+  const parentPane = panes.find((pane) => !pane.is_plugin && pane.id === parentPaneId);
+  if (!parentPane || typeof parentPane.tab_id !== "number") return null;
+
+  const tabPanes = panes
+    .filter((pane) => pane.tab_id === parentPane.tab_id)
+    .filter(isUsableZellijTiledPane);
+
+  return { parentPane, tabPanes };
+}
+
+export function selectZellijStackPlacement(
+  panes: ZellijPaneSnapshot[],
+  parentPaneId: number,
+): ZellijPlacementPlan | null {
+  const tabInfo = zellijTabPanesForParent(panes, parentPaneId);
+  if (!tabInfo) return null;
+
+  const stackTarget = tabInfo.tabPanes
+    .filter((pane) => pane.id !== parentPaneId)
+    .sort((a, b) => paneArea(b) - paneArea(a))[0];
+  if (!stackTarget) return null;
+
+  return {
+    mode: "stack",
+    anchorPaneId: stackTarget.id,
+    targetPaneId: stackTarget.id,
+    tabId: tabInfo.parentPane.tab_id!,
+  };
+}
+
+export function selectZellijPlacement(
+  panes: ZellijPaneSnapshot[],
+  parentPaneId: number,
+  minColumns = DEFAULT_ZELLIJ_SUBAGENT_MIN_COLUMNS,
+  minRows = DEFAULT_ZELLIJ_SUBAGENT_MIN_ROWS,
+): ZellijPlacementPlan | null {
+  const tabInfo = zellijTabPanesForParent(panes, parentPaneId);
+  if (!tabInfo) return null;
+
+  const zellijSplitCandidates = tabInfo.tabPanes
+    .map((pane) => ({ pane, splitDirection: predictZellijSplitDirection(pane) }))
+    .filter(
+      (candidate): candidate is { pane: ZellijPaneSnapshot; splitDirection: ZellijSplitDirection } =>
+        candidate.splitDirection !== null &&
+        canSplitZellijPane(candidate.pane, ZELLIJ_MIN_TERMINAL_WIDTH, ZELLIJ_MIN_TERMINAL_HEIGHT),
+    );
+
+  const safeSplitCandidates = zellijSplitCandidates.filter((candidate) =>
+    canSplitZellijPane(candidate.pane, minColumns, minRows),
+  );
+
+  // Split creation is tab-scoped, so Zellij chooses the concrete split pane.
+  // Only split when every pane Zellij might split would remain usable.
+  if (
+    zellijSplitCandidates.length > 0 &&
+    safeSplitCandidates.length === zellijSplitCandidates.length
+  ) {
+    const splitTarget = safeSplitCandidates.sort((a, b) => paneArea(b.pane) - paneArea(a.pane))[0];
+    return {
+      mode: "split",
+      anchorPaneId: splitTarget.pane.id,
+      targetPaneId: splitTarget.pane.id,
+      tabId: tabInfo.parentPane.tab_id!,
+      splitDirection: splitTarget.splitDirection,
+    };
+  }
+
+  return selectZellijStackPlacement(panes, parentPaneId);
+}
+
+function parseZellijPaneSurface(rawId: string, context: string): string {
+  const idMatch = rawId.match(/(\d+)/);
+  if (!idMatch) {
+    throw new Error(`Unexpected zellij pane id from ${context}: ${rawId || "(empty)"}`);
+  }
+  return `pane:${idMatch[1]}`;
+}
+
+function readZellijPanes(): ZellijPaneSnapshot[] {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const output = zellijActionSync(["list-panes", "--json", "--geometry", "--state", "--tab"]);
+      if (!output.trim()) {
+        throw new Error("Unexpected zellij list-panes output: empty");
+      }
+      const parsed = JSON.parse(output);
+      if (!Array.isArray(parsed)) {
+        throw new Error("Unexpected zellij list-panes output: not an array");
+      }
+      return parsed as ZellijPaneSnapshot[];
+    } catch (error) {
+      lastError = error;
+      if (attempt < 2) sleepSync(50);
+    }
+  }
+  throw lastError;
+}
+
+function createZellijTiledPane(name: string, tabId: number): string {
+  const args = ["new-pane", "--tab-id", String(tabId), "--name", name, "--cwd", process.cwd()];
+  return parseZellijPaneSurface(zellijActionSync(args).trim(), "new-pane");
+}
+
+function createZellijStackedPane(name: string, anchorSurface: string): string {
+  const args = [
+    "new-pane",
+    "--stacked",
+    "--near-current-pane",
+    "--name",
+    name,
+    "--cwd",
+    process.cwd(),
+  ];
+  return parseZellijPaneSurface(zellijActionSync(args, anchorSurface).trim(), "new-pane --stacked");
+}
+
+function createZellijTab(name: string): string {
+  const tabIdRaw = zellijActionSync(["new-tab", "--name", name, "--cwd", process.cwd()]).trim();
+  const tabId = Number(tabIdRaw);
+  if (!Number.isInteger(tabId)) {
+    throw new Error(`Unexpected zellij tab id from new-tab: ${tabIdRaw || "(empty)"}`);
+  }
+
+  try {
+    const panes = readZellijPanes();
+    const pane = panes.find(
+      (candidate) =>
+        candidate.tab_id === tabId &&
+        isUsableZellijTiledPane(candidate) &&
+        typeof candidate.id === "number",
+    );
+    if (!pane) {
+      throw new Error(`Could not find initial pane for zellij tab ${tabId}`);
+    }
+
+    const surface = `pane:${pane.id}`;
+    try {
+      zellijActionSync(["rename-pane", name], surface);
+    } catch {
+      // Optional.
+    }
+    return surface;
+  } catch (error) {
+    try {
+      zellijActionSync(["close-tab", "--tab-id", String(tabId)]);
+    } catch {
+      // Best effort cleanup for tabs created before post-creation inspection failed.
+    }
+    throw error;
+  }
+}
+
+function envPositiveInteger(name: string, fallback: number): number {
+  const value = Number(process.env[name]);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function sleepSync(milliseconds: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function zellijSurfaceLockPath(): string {
+  const session = (process.env.ZELLIJ_SESSION_NAME ?? process.env.ZELLIJ ?? "default").replace(
+    /[^A-Za-z0-9_.-]/g,
+    "_",
+  );
+  return join(tmpdir(), `pi-zellij-surface-${session}.lock`);
+}
+
+function withZellijSurfaceLock<T>(callback: () => T): T {
+  const lockPath = zellijSurfaceLockPath();
+  const deadline = Date.now() + 10000;
+
+  while (true) {
+    try {
+      mkdirSync(lockPath);
+      writeFileSync(join(lockPath, "owner"), `${process.pid}\n`);
+      break;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") throw error;
+
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > 30000) {
+          rmSync(lockPath, { recursive: true, force: true });
+          continue;
+        }
+      } catch {}
+
+      if (Date.now() > deadline) {
+        throw new Error(`Timed out waiting for zellij surface lock: ${lockPath}`);
+      }
+      sleepSync(50);
+    }
+  }
+
+  try {
+    return callback();
+  } finally {
+    rmSync(lockPath, { recursive: true, force: true });
+  }
+}
+
+function createZellijSurfaceUnlocked(name: string): string {
+  const parentPaneIdRaw = process.env.ZELLIJ_PANE_ID;
+  const parentPaneId = parentPaneIdRaw ? Number(parentPaneIdRaw) : NaN;
+  const minColumns = envPositiveInteger(
+    "PI_SUBAGENT_ZELLIJ_MIN_COLUMNS",
+    DEFAULT_ZELLIJ_SUBAGENT_MIN_COLUMNS,
+  );
+  const minRows = envPositiveInteger(
+    "PI_SUBAGENT_ZELLIJ_MIN_ROWS",
+    DEFAULT_ZELLIJ_SUBAGENT_MIN_ROWS,
+  );
+
+  const plan = Number.isInteger(parentPaneId)
+    ? selectZellijPlacement(readZellijPanes(), parentPaneId, minColumns, minRows)
+    : null;
+
+  if (plan?.mode === "split") {
+    return createZellijTiledPane(name, plan.tabId);
+  }
+
+  if (plan?.mode === "stack") {
+    return createZellijStackedPane(name, `pane:${plan.targetPaneId}`);
+  }
+
+  return createZellijTab(name);
+}
+
+function createZellijSurface(name: string): string {
+  return withZellijSurfaceLock(() => createZellijSurfaceUnlocked(name));
+}
 
 type CmuxFocusSnapshot = {
   surfaceRef?: string;
@@ -421,7 +746,8 @@ function createCmuxSplitSurface(
  *
  * For cmux: the first call creates a right-split pane; subsequent calls add
  * tabs to that same pane (avoiding ever-narrower splits).
- * For tmux/zellij/wezterm: falls back to split behavior.
+ * For zellij: chooses a tab-aware tiled or stacked placement.
+ * For tmux/wezterm: falls back to split behavior.
  *
  * Returns an identifier (`surface:42` in cmux, `%12` in tmux, `pane:7` in zellij, `42` in wezterm).
  */
@@ -444,6 +770,10 @@ export function createSurface(name: string): string {
     const created = createCmuxSplitSurface(name, "right", process.env.CMUX_SURFACE_ID);
     cmuxSubagentPane = created.paneRef ?? null;
     return created.surface;
+  }
+
+  if (backend === "zellij") {
+    return createZellijSurface(name);
   }
 
   // On tmux, target the parent pi's pane so splits follow the agent, not the user's focus.
@@ -555,13 +885,7 @@ export function createSurfaceSplit(
   // zellij returns the pane ID as e.g. "terminal_7" — extract the numeric part.
   // Previously we sent `write-chars "echo $ZELLIJ_PANE_ID"` to a temp file, but
   // `write-chars` without --pane-id targets the focused pane, which raced on tab switches.
-  const idMatch = rawId.match(/(\d+)/);
-  if (!idMatch) {
-    throw new Error(`Unexpected zellij pane id from new-pane: ${rawId || "(empty)"}`);
-  }
-  const paneId = idMatch[1];
-
-  const surface = `pane:${paneId}`;
+  const surface = parseZellijPaneSurface(rawId, "new-pane");
 
   if (direction === "left" || direction === "up") {
     try {

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -2,7 +2,7 @@
  * Integration test harness for pi-interactive-subagents.
  *
  * Provides utilities to:
- * - Detect available mux backends (cmux, tmux)
+ * - Detect available mux backends (cmux, tmux, zellij)
  * - Create isolated test environments with test agent definitions
  * - Start real pi sessions in mux surfaces
  * - Poll for file creation and screen output
@@ -89,7 +89,7 @@ export function getAvailableBackends(): MuxBackend[] {
   const backends: MuxBackend[] = [];
   const orig = process.env.PI_SUBAGENT_MUX;
 
-  for (const backend of ["cmux", "tmux"] as MuxBackend[]) {
+  for (const backend of ["cmux", "tmux", "zellij"] as MuxBackend[]) {
     process.env.PI_SUBAGENT_MUX = backend;
     try {
       if (getMuxBackend() === backend) backends.push(backend);

--- a/test/integration/mux-surface.test.ts
+++ b/test/integration/mux-surface.test.ts
@@ -1,13 +1,14 @@
 /**
  * Integration tests for the multiplexer surface layer.
  *
- * These tests exercise real cmux/tmux operations: creating panes,
+ * These tests exercise real mux operations: creating panes,
  * sending commands, reading screen output, and closing surfaces.
  * No LLM calls — fast and free.
  *
  * Run inside a supported multiplexer:
  *   cmux bash -c 'npm run test:integration'
  *   tmux new 'npm run test:integration'
+ *   zellij --session pi  # then run: npm run test:integration
  */
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";

--- a/test/test.ts
+++ b/test/test.ts
@@ -26,6 +26,10 @@ import {
   parseCmuxJson,
   parseCmuxPaneRefForSurface,
   parseCmuxPaneRefForSurfaceFromJson,
+  canSplitZellijPane,
+  predictZellijSplitDirection,
+  selectZellijPlacement,
+  selectZellijStackPlacement,
 } from "../pi-extension/subagents/cmux.ts";
 import {
   advanceStatusState,
@@ -2020,6 +2024,159 @@ describe("cmux.ts", () => {
         ),
         "pane:4",
       );
+    });
+  });
+
+  describe("zellij placement", () => {
+    const pane = (overrides: any) => ({
+      id: 1,
+      is_plugin: false,
+      is_floating: false,
+      is_selectable: true,
+      exited: false,
+      pane_rows: 20,
+      pane_columns: 80,
+      tab_id: 1,
+      ...overrides,
+    });
+
+    it("matches Zellij direction and minimum split rules", () => {
+      assert.equal(predictZellijSplitDirection(pane({ pane_rows: 5, pane_columns: 11 })), "right");
+      assert.equal(predictZellijSplitDirection(pane({ pane_rows: 11, pane_columns: 5 })), "down");
+      assert.equal(predictZellijSplitDirection(pane({ pane_rows: 5, pane_columns: 10 })), null);
+      assert.equal(predictZellijSplitDirection(pane({ pane_rows: 4, pane_columns: 80 })), null);
+
+      assert.equal(canSplitZellijPane(pane({ pane_rows: 5, pane_columns: 11 })), true);
+      assert.equal(canSplitZellijPane(pane({ pane_rows: 11, pane_columns: 5 })), true);
+      assert.equal(canSplitZellijPane(pane({ pane_rows: 5, pane_columns: 10 })), false);
+      assert.equal(canSplitZellijPane(pane({ pane_rows: 4, pane_columns: 80 })), false);
+
+      assert.equal(canSplitZellijPane(pane({ pane_rows: 30, pane_columns: 100 }), 80, 20), false);
+      assert.equal(canSplitZellijPane(pane({ pane_rows: 45, pane_columns: 100 }), 80, 20), true);
+      assert.equal(canSplitZellijPane(pane({ pane_rows: 30, pane_columns: 170 }), 80, 20), true);
+      assert.equal(canSplitZellijPane(pane({ pane_rows: 31, pane_columns: 47 }), 50, 10), false);
+      assert.equal(canSplitZellijPane(pane({ pane_rows: 31, pane_columns: 77 }), 50, 10), true);
+    });
+
+    it("uses tab-scoped split only when all Zellij split candidates are safe", () => {
+      const plan = selectZellijPlacement(
+        [
+          pane({ id: 10, tab_id: 1, pane_rows: 40, pane_columns: 120 }),
+          pane({ id: 11, tab_id: 1, pane_rows: 120, pane_columns: 100 }),
+          pane({ id: 12, tab_id: 2, pane_rows: 60, pane_columns: 200 }),
+        ],
+        10,
+      );
+
+      assert.deepEqual(plan, {
+        mode: "split",
+        anchorPaneId: 11,
+        targetPaneId: 11,
+        tabId: 1,
+        splitDirection: "down",
+      });
+    });
+
+    it("stacks when any Zellij split candidate would fall below Pi's configured minimum", () => {
+      const plan = selectZellijPlacement(
+        [
+          pane({ id: 10, tab_id: 1, pane_rows: 100, pane_columns: 47 }),
+          pane({ id: 11, tab_id: 1, pane_rows: 31, pane_columns: 77 }),
+        ],
+        10,
+        50,
+        10,
+      );
+
+      assert.deepEqual(plan, {
+        mode: "stack",
+        anchorPaneId: 11,
+        targetPaneId: 11,
+        tabId: 1,
+      });
+    });
+
+    it("stacks when Zellij would split a pane below Pi's usable minimum", () => {
+      const plan = selectZellijPlacement(
+        [
+          pane({ id: 10, tab_id: 1, pane_rows: 20, pane_columns: 20 }),
+          pane({ id: 11, tab_id: 1, pane_rows: 18, pane_columns: 60 }),
+          pane({ id: 12, tab_id: 1, pane_rows: 10, pane_columns: 70 }),
+        ],
+        10,
+      );
+
+      assert.deepEqual(plan, {
+        mode: "stack",
+        anchorPaneId: 11,
+        targetPaneId: 11,
+        tabId: 1,
+      });
+    });
+
+    it("never chooses the parent pane as the stack target", () => {
+      const plan = selectZellijStackPlacement(
+        [
+          pane({ id: 10, tab_id: 1, pane_rows: 60, pane_columns: 200 }),
+          pane({ id: 11, tab_id: 1, pane_rows: 10, pane_columns: 20 }),
+          pane({ id: 12, tab_id: 1, pane_rows: 8, pane_columns: 30 }),
+        ],
+        10,
+      );
+
+      assert.deepEqual(plan, {
+        mode: "stack",
+        anchorPaneId: 12,
+        targetPaneId: 12,
+        tabId: 1,
+      });
+    });
+
+    it("does not stack when the only usable pane is the parent", () => {
+      const plan = selectZellijStackPlacement(
+        [pane({ id: 10, tab_id: 1, pane_rows: 60, pane_columns: 200 })],
+        10,
+      );
+
+      assert.equal(plan, null);
+    });
+
+    it("stacks on the largest usable non-parent pane when none can split", () => {
+      const plan = selectZellijPlacement(
+        [
+          pane({ id: 10, tab_id: 1, pane_rows: 5, pane_columns: 10 }),
+          pane({ id: 11, tab_id: 1, pane_rows: 6, pane_columns: 8 }),
+          pane({ id: 12, tab_id: 2, pane_rows: 60, pane_columns: 200 }),
+        ],
+        10,
+      );
+
+      assert.deepEqual(plan, {
+        mode: "stack",
+        anchorPaneId: 11,
+        targetPaneId: 11,
+        tabId: 1,
+      });
+    });
+
+    it("ignores floating, plugin, exited, unselectable, and other-tab panes", () => {
+      const plan = selectZellijPlacement(
+        [
+          pane({ id: 10, tab_id: 1, pane_rows: 5, pane_columns: 10 }),
+          pane({ id: 11, tab_id: 1, pane_rows: 60, pane_columns: 200, is_floating: true }),
+          pane({ id: 12, tab_id: 1, pane_rows: 60, pane_columns: 200, is_plugin: true }),
+          pane({ id: 13, tab_id: 1, pane_rows: 60, pane_columns: 200, exited: true }),
+          pane({ id: 14, tab_id: 1, pane_rows: 60, pane_columns: 200, is_selectable: false }),
+          pane({ id: 15, tab_id: 2, pane_rows: 60, pane_columns: 200 }),
+        ],
+        10,
+      );
+
+      assert.equal(plan, null);
+    });
+
+    it("returns null when the parent pane cannot be found", () => {
+      assert.equal(selectZellijPlacement([pane({ id: 10 })], 99), null);
     });
   });
 


### PR DESCRIPTION
## Summary

Improves Zellij pane placement for subagents so large batches can launch reliably while making better use of available screen space.

Previously, normal Zellij subagent launches forced every new pane with `new-pane --direction right`. That repeatedly split relative to the focused or anchored pane, quickly producing narrow columns. Once panes became too small for another forced right split, Zellij would start rejecting new panes, so spawning many subagents failed early.

This PR removes the forced-right split path and uses Zellij's tab-level directionless placement behavior instead. Pi inspects the parent tab, predicts whether Zellij's next tab-scoped split should remain usable, and only lets Zellij split when every pane it might choose is safe under Pi's configured minimums. When no safe split remains, Pi stacks on a non-parent pane instead.

## What changed

- Use `zellij action list-panes --json --geometry --state --tab` to inspect the parent Pi tab.
- Select placement candidates from usable tiled panes in that tab.
- Predict Zellij's directionless split direction using its row/column ratio.
- Enforce practical Pi minimums before allowing a tab-scoped split.
- Add configurable Zellij subagent minimums:
  - `PI_SUBAGENT_ZELLIJ_MIN_COLUMNS`
  - `PI_SUBAGENT_ZELLIJ_MIN_ROWS`
- Stack instead of splitting when any Zellij split candidate would fall below the configured minimums.
- Avoid stacking on the parent Pi pane.
- Serialize Zellij surface creation so parallel subagent launches do not race on stale layout snapshots.
- Retry transient `list-panes` JSON failures and clean up newly-created fallback tabs if post-create inspection fails.
- Fall back to a new tab only when there is no split or stack placement available.
- Add focused unit coverage for Zellij placement behavior.
- Include Zellij in integration backend detection.

## Defaults

Current defaults are:

```text
PI_SUBAGENT_ZELLIJ_MIN_COLUMNS=50
PI_SUBAGENT_ZELLIJ_MIN_ROWS=10
```

These are practical Pi usability minimums, not Zellij's hard internal minimums.

## Tradeoff

This intentionally gives up the old "always split right" behavior. That behavior was spatially predictable, but it exhausted horizontal space quickly and caused launches to fail. The new behavior follows Zellij's tab-level placement model and prioritizes usable screen space across large batches. Exact per-pane split targeting is left for a future deterministic layout pass so this PR does not manipulate user focus.

## Related issue

Refs #33 for the Zellij side of focus-neutral launches. This PR does not add a general mux-level `preserveFocus` policy for every backend, but the new Zellij path no longer steals focus in live testing: normal tiled splits use tab-scoped creation (`new-pane --tab-id`) and the implementation does not focus panes as part of placement. Stack placement remains pane-id anchored so it can avoid the parent pane.

## Testing

Automated:

```bash
bun test ./test/test.ts -t "cmux.ts"
bun test --timeout 30000 ./test/integration/mux-surface.test.ts -t "creates a surface"
git diff --check
```

Manual Zellij validation:

- Spawned 20 real sleeper subagents in parallel from inside Pi.
- Verified the old forced-right failure mode no longer occurs.
- Verified panes stop splitting once Zellij's tab-scoped split could fall below the configured minimums.
- Verified placement switches to stacking when no safe split remains.
- Verified stacks avoid the parent Pi pane.
- Verified the parallel launch lock prevents stale-layout split races.


