### PR TITLE
fix: wake cmux surfaces in hidden workspaces before sending launch commands

### DIFF
--- a/pi-extension/subagents/cmux.ts
+++ b/pi-extension/subagents/cmux.ts
@@ -530,6 +530,7 @@ function createZellijSurface(name: string): string {
 type CmuxFocusSnapshot = {
   surfaceRef?: string;
   paneRef?: string;
+  workspaceRef?: string;
 };
 
 type CmuxCreatedSurface = {
@@ -552,12 +553,13 @@ export function parseCmuxFocusedSnapshot(value: unknown): CmuxFocusSnapshot | nu
   const focused = (value as { focused?: unknown }).focused;
   if (!focused || typeof focused !== "object") return null;
 
-  const record = focused as { surface_ref?: unknown; pane_ref?: unknown };
+  const record = focused as { surface_ref?: unknown; pane_ref?: unknown; workspace_ref?: unknown };
   const surfaceRef = nonEmptyString(record.surface_ref) ? record.surface_ref : undefined;
   const paneRef = nonEmptyString(record.pane_ref) ? record.pane_ref : undefined;
+  const workspaceRef = nonEmptyString(record.workspace_ref) ? record.workspace_ref : undefined;
 
-  if (!surfaceRef && !paneRef) return null;
-  return { surfaceRef, paneRef };
+  if (!surfaceRef && !paneRef && !workspaceRef) return null;
+  return { surfaceRef, paneRef, ...(workspaceRef ? { workspaceRef } : {}) };
 }
 
 export function parseCmuxJson(value: string): unknown | null {
@@ -579,12 +581,13 @@ function parseCmuxCallerSnapshot(value: unknown): CmuxFocusSnapshot | null {
   const caller = (value as { caller?: unknown }).caller;
   if (!caller || typeof caller !== "object") return null;
 
-  const record = caller as { surface_ref?: unknown; pane_ref?: unknown };
+  const record = caller as { surface_ref?: unknown; pane_ref?: unknown; workspace_ref?: unknown };
   const surfaceRef = nonEmptyString(record.surface_ref) ? record.surface_ref : undefined;
   const paneRef = nonEmptyString(record.pane_ref) ? record.pane_ref : undefined;
+  const workspaceRef = nonEmptyString(record.workspace_ref) ? record.workspace_ref : undefined;
 
-  if (!surfaceRef && !paneRef) return null;
-  return { surfaceRef, paneRef };
+  if (!surfaceRef && !paneRef && !workspaceRef) return null;
+  return { surfaceRef, paneRef, ...(workspaceRef ? { workspaceRef } : {}) };
 }
 
 export function parseCmuxPaneRefForSurface(value: unknown, surface: string): string | null {
@@ -710,6 +713,34 @@ function renameCmuxSurface(surface: string, name: string): void {
   execFileSync("cmux", ["rename-tab", "--surface", surface, name], { encoding: "utf8" });
 }
 
+function isCmuxCallerWorkspaceHidden(snapshot: CmuxIdentifySnapshot): boolean {
+  const callerWorkspace = snapshot.caller?.workspaceRef;
+  const focusedWorkspace = snapshot.focused?.workspaceRef;
+  return !!callerWorkspace && !!focusedWorkspace && callerWorkspace !== focusedWorkspace;
+}
+
+/**
+ * Wake a freshly-created cmux surface before sending the real launch command.
+ *
+ * cmux lazily initializes terminal surfaces in workspaces that are not currently
+ * focused. If the first text sent to such a surface is the real command, cmux
+ * may render that text before shell startup and never evaluate it. A harmless
+ * newline forces initialization without changing focus; the existing shell-ready
+ * delay can then wait for the prompt normally.
+ */
+function wakeCmuxSurfaceForInputIfCallerHidden(
+  surface: string,
+  identifySnapshot: CmuxIdentifySnapshot,
+): void {
+  if (!isCmuxCallerWorkspaceHidden(identifySnapshot)) return;
+
+  try {
+    execFileSync("cmux", ["send", "--surface", surface, "\n"], { encoding: "utf8" });
+  } catch {
+    // Best effort. Normal focused surfaces and already-initialized terminals do not need this.
+  }
+}
+
 function createCmuxSplitSurface(
   name: string,
   direction: "left" | "right" | "up" | "down",
@@ -728,6 +759,7 @@ function createCmuxSplitSurface(
     child = parseCmuxCreatedSurface(output, "new-split");
     child.paneRef ??= readCmuxPaneRefForSurface(child.surface) ?? undefined;
     renameCmuxSurface(child.surface, name);
+    wakeCmuxSurfaceForInputIfCallerHidden(child.surface, identifySnapshot);
     return child;
   } finally {
     if (child) {
@@ -796,6 +828,7 @@ function createSurfaceInPane(name: string, pane: string): string {
     child = parseCmuxCreatedSurface(output, "new-surface");
     child.paneRef ??= pane;
     renameCmuxSurface(child.surface, name);
+    wakeCmuxSurfaceForInputIfCallerHidden(child.surface, identifySnapshot);
     return child.surface;
   } finally {
     if (child) {

--- a/test/integration/mux-surface.test.ts
+++ b/test/integration/mux-surface.test.ts
@@ -12,6 +12,7 @@
  */
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { unlinkSync } from "node:fs";
 import {
   getAvailableBackends,
@@ -40,6 +41,24 @@ import {
   type TestEnv,
 } from "./harness.ts";
 
+function cmuxIdentify(): {
+  caller?: { workspace_ref?: string };
+  focused?: { workspace_ref?: string };
+} {
+  return JSON.parse(execFileSync("cmux", ["identify", "--json"], { encoding: "utf8" }));
+}
+
+function cmuxWorkspaceRefs(): string[] {
+  return execFileSync("cmux", ["list-workspaces"], { encoding: "utf8" })
+    .split("\n")
+    .map((line) => line.match(/workspace:\d+/)?.[0])
+    .filter((workspace): workspace is string => !!workspace);
+}
+
+function cmuxSelectWorkspace(workspace: string): void {
+  execFileSync("cmux", ["select-workspace", "--workspace", workspace], { encoding: "utf8" });
+}
+
 const backends = getAvailableBackends();
 const FOCUS_TEST_SHELL_READY_DELAY_MS = Number(process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS ?? "2500");
 
@@ -61,6 +80,67 @@ for (const backend of backends) {
     after(() => {
       cleanupTestEnv(env);
       restoreBackend(prevMux);
+    });
+
+    it("executes long commands in hidden cmux workspaces", async (t) => {
+      if (backend !== "cmux") {
+        t.skip("cmux-specific lazy terminal initialization regression");
+        return;
+      }
+
+      const initial = cmuxIdentify();
+      const callerWorkspace = initial.caller?.workspace_ref;
+      const originalFocusedWorkspace = initial.focused?.workspace_ref;
+
+      if (!callerWorkspace || !originalFocusedWorkspace) {
+        t.skip("cmux identify did not report caller/focused workspaces");
+        return;
+      }
+
+      const awayWorkspace = cmuxWorkspaceRefs().find((workspace) => workspace !== callerWorkspace);
+      if (!awayWorkspace) {
+        t.skip("requires at least two cmux workspaces");
+        return;
+      }
+
+      const shouldRestoreFocus = originalFocusedWorkspace === callerWorkspace;
+      if (shouldRestoreFocus) {
+        cmuxSelectWorkspace(awayWorkspace);
+        await sleep(500);
+      }
+
+      const hidden = cmuxIdentify();
+      assert.notEqual(
+        hidden.focused?.workspace_ref,
+        callerWorkspace,
+        "test setup should leave the caller workspace hidden",
+      );
+
+      const surface = createTrackedSurface(env, "hidden-long-cmd-test");
+
+      try {
+        const marker = `HIDDEN_LONG_${uniqueId()}`;
+
+        // Match the subagent launch sequence: create a surface, wait for shell
+        // readiness, then send a script-backed command. Without the cmux wake
+        // workaround, hidden surfaces can render the `bash <script>` text before
+        // shell startup and never evaluate it.
+        await sleep(2500);
+        sendLongCommand(surface, `echo ${marker}`);
+
+        await waitForScreen(surface, new RegExp(`^${marker}$`, "m"), 10_000, 100);
+      } finally {
+        try {
+          closeSurface(surface);
+        } catch {}
+        untrackSurface(env, surface);
+
+        if (shouldRestoreFocus) {
+          try {
+            cmuxSelectWorkspace(originalFocusedWorkspace);
+          } catch {}
+        }
+      }
     });
 
     it("keeps focus on the active surface while creating and targeting subagent surfaces", async () => {


### PR DESCRIPTION
## Problem

When a subagent is spawned while the user is viewing a different cmux workspace the launch command isn't evaluated. 

Example, if you prompt the main agent, Cmd+2 to another workspace before the subagent pane is created, the new split pane opens, the shell-ready delay passes, and the `bash <script>` command is sent but not evaluated. You'll see it there when you switch back to the initial workspace.

## Root Cause

Creating a fresh cmux surface in a hidden workspace creates the surface but defers terminal/PTY initialization until the surface receives activity or the workspace becomes visible. The first `cmux send` to the surface triggers initialization, but its payload is consumed as display text rather than shell input — the shell hasn't started yet when the text arrives.

Confirmed via a red/green cmux integration test that uses the same low-level launch shape as subagents (`sendLongCommand()` → `bash <script>`), without any LLM call:
   - **Pre-fix:** the hidden split renders `bash <script>` before the login banner, but the script never executes (`TEXT_ONLY`)
   - **Post-fix:** the marker emitted by the script appears on screen, proving the command executed

## Fix

Layered the wake behavior into the cmux surface creation paths introduced by #36.

After creating and renaming a fresh cmux surface, `cmux.ts` checks the pre-create `cmux identify --json` snapshot. If the caller workspace differs from the focused workspace, the caller workspace is hidden, so Pi sends a harmless `\n` to the newly-created target surface. This forces cmux to initialize the hidden terminal before the existing shell-ready delay sends the real launch command.

The wake is applied in both fresh cmux creation paths:
- `createCmuxSplitSurface()`
- `createSurfaceInPane()`

This preserves #36’s focus-neutral behaviour: no `focus-pane`, no `select-workspace`, and no replacement of the `CMUX_SURFACE_ID` anchored creation flow.