### PR TITLE
fix(subagents): report manually quit child sessions

### DIFF
--- a/pi-extension/subagents/cmux.ts
+++ b/pi-extension/subagents/cmux.ts
@@ -1217,7 +1217,7 @@ export function closeSurface(surface: string): void {
 
 export interface PollResult {
   /** How the subagent exited */
-  reason: "done" | "ping" | "sentinel" | "error";
+  reason: "done" | "ping" | "sentinel" | "error" | "quit";
   /** Shell exit code (from sentinel). 0 for file-based exits. */
   exitCode: number;
   /** Ping data if reason is "ping" */
@@ -1245,6 +1245,9 @@ function interpretExitSidecar(data: any): PollResult {
         ? data.errorMessage
         : "Subagent exited with stopReason=error (no errorMessage in sidecar).";
     return { reason: "error", exitCode: 1, errorMessage };
+  }
+  if (data?.type === "quit") {
+    return { reason: "quit", exitCode: 0 };
   }
   return { reason: "done", exitCode: 0 };
 }

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -20,6 +20,7 @@ import {
   createSurface,
   sendLongCommand,
   pollForExit,
+  type PollResult,
   closeSurface,
   getMuxBackend,
   sendEscape,
@@ -439,13 +440,20 @@ function formatWidgetRightLabel(snapshot: StatusSnapshot): string {
 function resolveResultPresentation(
   result: Pick<
     SubagentResult,
-    "exitCode" | "elapsed" | "summary" | "sessionFile" | "errorMessage"
+    "exitCode" | "elapsed" | "summary" | "sessionFile" | "errorMessage" | "exitReason"
   >,
   name: string,
 ): string {
   const sessionRef = result.sessionFile
     ? `\n\nSession: ${result.sessionFile}\nResume: pi --session ${result.sessionFile}`
     : "";
+
+  if (result.exitReason === "quit") {
+    return (
+      `Sub-agent "${name}" closed by user (${formatElapsed(result.elapsed)}).\n\n` +
+      `${result.summary}${sessionRef}`
+    );
+  }
 
   if (result.errorMessage) {
     // Auto-retry exhausted or other agent-loop error. The subagent did not
@@ -478,6 +486,7 @@ interface SubagentResult {
   exitCode: number;
   elapsed: number;
   error?: string;
+  exitReason?: PollResult["reason"];
   /** Provider/agent error message when auto-retry exhausted (overload, rate limit, etc.). */
   errorMessage?: string;
   ping?: { name: string; message: string };
@@ -892,6 +901,20 @@ function resolveResumeLaunchBehavior(params: { autoExit?: boolean }): { autoExit
   return { autoExit, interactive: !autoExit };
 }
 
+function resolveResumeSummary(
+  entries: any[],
+  result: Pick<SubagentResult, "errorMessage" | "exitCode" | "exitReason">,
+): string {
+  return findLastAssistantMessage(entries) ??
+    (result.errorMessage
+      ? `Subagent error: ${result.errorMessage}`
+      : result.exitReason === "quit"
+        ? "Sub-agent session was closed by the user before it called subagent_done."
+        : result.exitCode !== 0
+          ? `Resumed session exited with code ${result.exitCode}`
+          : "Resumed session exited without new output");
+}
+
 export const __test__ = {
   borderLine,
   getShellReadyDelayMs,
@@ -911,6 +934,7 @@ export const __test__ = {
   handleSubagentInterrupt,
   resolveResultPresentation,
   resolveResumeLaunchBehavior,
+  resolveResumeSummary,
   runningSubagents,
   formatElapsed,
 };
@@ -1294,7 +1318,15 @@ async function watchSubagent(
       closeSurface(surface);
       runningSubagents.delete(running.id);
 
-      return { name, task, summary, exitCode: result.exitCode, elapsed, ...(sessionId ? { claudeSessionId: sessionId } : {}) };
+      return {
+        name,
+        task,
+        summary,
+        exitCode: result.exitCode,
+        elapsed,
+        exitReason: result.reason,
+        ...(sessionId ? { claudeSessionId: sessionId } : {}),
+      };
     }
 
     // Pi subagent result extraction
@@ -1305,15 +1337,19 @@ async function watchSubagent(
         findLastAssistantMessage(allEntries) ??
         (result.errorMessage
           ? `Subagent error: ${result.errorMessage}`
-          : result.exitCode !== 0
-            ? `Sub-agent exited with code ${result.exitCode}`
-            : "Sub-agent exited without output");
+          : result.reason === "quit"
+            ? "Sub-agent session was closed by the user before it called subagent_done."
+            : result.exitCode !== 0
+              ? `Sub-agent exited with code ${result.exitCode}`
+              : "Sub-agent exited without output");
     } else {
       summary = result.errorMessage
         ? `Subagent error: ${result.errorMessage}`
-        : result.exitCode !== 0
-          ? `Sub-agent exited with code ${result.exitCode}`
-          : "Sub-agent exited without output";
+        : result.reason === "quit"
+          ? "Sub-agent session was closed by the user before it called subagent_done."
+          : result.exitCode !== 0
+            ? `Sub-agent exited with code ${result.exitCode}`
+            : "Sub-agent exited without output";
     }
 
     closeSurface(surface);
@@ -1326,6 +1362,7 @@ async function watchSubagent(
       sessionFile,
       exitCode: result.exitCode,
       elapsed,
+      exitReason: result.reason,
       ping: result.ping,
       ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
     };
@@ -1496,6 +1533,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
                   agent: running.agent,
                   exitCode: result.exitCode,
                   elapsed: result.elapsed,
+                  exitReason: result.exitReason,
                   sessionFile: result.sessionFile,
                   ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
                   ...(result.claudeSessionId ? { claudeSessionId: result.claudeSessionId } : {}),
@@ -1909,12 +1947,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
             }
 
             const allEntries = getNewEntries(params.sessionPath, entryCountBefore);
-            const summary = findLastAssistantMessage(allEntries) ??
-              (result.errorMessage
-                ? `Subagent error: ${result.errorMessage}`
-                : result.exitCode !== 0
-                  ? `Resumed session exited with code ${result.exitCode}`
-                  : "Resumed session exited without new output");
+            const summary = resolveResumeSummary(allEntries, result);
             const presentation = resolveResultPresentation(
               { ...result, summary, sessionFile: params.sessionPath },
               name,
@@ -1930,6 +1963,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
                   task: params.message ?? "resumed session",
                   exitCode: result.exitCode,
                   elapsed: result.elapsed,
+                  exitReason: result.exitReason,
                   sessionFile: params.sessionPath,
                   ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
                 },
@@ -2015,7 +2049,9 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         const name = details.name ?? "subagent";
         const exitCode = details.exitCode ?? 0;
         const errorMessage = typeof details.errorMessage === "string" ? details.errorMessage : "";
-        const failed = exitCode !== 0 || !!errorMessage;
+        const exitReason = details.exitReason;
+        const closedByUser = exitReason === "quit";
+        const failed = !closedByUser && (exitCode !== 0 || !!errorMessage);
         const elapsed = details.elapsed != null ? formatElapsed(details.elapsed) : "?";
         const bgFn = failed
           ? (text: string) => theme.bg("toolErrorBg", text)
@@ -2023,11 +2059,13 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         const icon = failed
           ? theme.fg("error", "✗")
           : theme.fg("success", "✓");
-        const status = errorMessage
-          ? "failed (provider/agent error)"
-          : failed
-            ? `failed (exit ${exitCode})`
-            : "completed";
+        const status = closedByUser
+          ? "closed by user"
+          : errorMessage
+            ? "failed (provider/agent error)"
+            : failed
+              ? `failed (exit ${exitCode})`
+              : "completed";
         const agentTag = details.agent ? theme.fg("dim", ` (${details.agent})`) : "";
 
         const header = `${icon} ${theme.fg("toolTitle", theme.bold(name))}${agentTag} ${theme.fg("dim", "—")} ${status} ${theme.fg("dim", `(${elapsed})`)}`;
@@ -2037,6 +2075,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         const summary = rawContent
           .replace(/\n\nSession: .+\nResume: .+$/, "")
           .replace(`Sub-agent "${name}" completed (${elapsed}).\n\n`, "")
+          .replace(`Sub-agent "${name}" closed by user (${elapsed}).\n\n`, "")
           .replace(`Sub-agent "${name}" failed (exit code ${exitCode}).\n\n`, "")
           .replace(
             new RegExp(

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -42,6 +42,31 @@ export interface SubagentErrorInfo {
   stopReason: "error";
 }
 
+type ChildExitSidecarPayload =
+  | { type: "done" }
+  | { type: "ping"; name: string; message: string }
+  | { type: "error"; errorMessage: string; stopReason: "error" }
+  | { type: "quit" };
+
+export type ExitSidecarWriteResult = "written" | "exists" | "missing-session" | "write-error";
+
+export function writeExitSidecarIfAbsent(
+  sessionFile: string | undefined,
+  payload: ChildExitSidecarPayload,
+): ExitSidecarWriteResult {
+  if (!sessionFile) return "missing-session";
+  const exitFile = `${sessionFile}.exit`;
+  try {
+    writeFileSync(exitFile, JSON.stringify(payload), { flag: "wx" });
+    return "written";
+  } catch (error) {
+    const code = typeof error === "object" && error !== null && "code" in error
+      ? (error as { code?: unknown }).code
+      : undefined;
+    return code === "EEXIST" ? "exists" : "write-error";
+  }
+}
+
 /**
  * If the last assistant message in the turn ended with `stopReason: "error"`
  * (typically auto-retry exhausted on an overload / rate limit / server error),
@@ -143,6 +168,18 @@ export default function (pi: ExtensionAPI) {
 
   let userTookOver = false;
   let agentStarted = false;
+  let exitSidecarClaimed = false;
+
+  function claimExitSidecar(
+    sessionFile: string | undefined,
+    payload: ChildExitSidecarPayload,
+  ): ExitSidecarWriteResult {
+    const result = writeExitSidecarIfAbsent(sessionFile, payload);
+    if (result === "written" || result === "exists") {
+      exitSidecarClaimed = true;
+    }
+    return result;
+  }
 
   // Show widget + status bar on session start
   pi.on("session_start", (_event, ctx) => {
@@ -183,20 +220,14 @@ export default function (pi: ExtensionAPI) {
       // assistant message, mistaking the crash for a successful completion.
       const errorInfo = findLatestAssistantError(messages);
       const sessionFile = process.env.PI_SUBAGENT_SESSION;
-      if (errorInfo && sessionFile) {
-        try {
-          writeFileSync(
-            `${sessionFile}.exit`,
-            JSON.stringify({
-              type: "error",
-              errorMessage: errorInfo.errorMessage,
-              stopReason: errorInfo.stopReason,
-            }),
-          );
-        } catch {
-          // Best effort — even without the sidecar, watcher's session-file
-          // fallback can still recover the errorMessage.
-        }
+      if (errorInfo) {
+        claimExitSidecar(sessionFile, {
+          type: "error",
+          errorMessage: errorInfo.errorMessage,
+          stopReason: errorInfo.stopReason,
+        });
+      } else {
+        claimExitSidecar(sessionFile, { type: "done" });
       }
 
       recorder.agentEndDone();
@@ -253,7 +284,12 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("session_shutdown", (event) => {
-    recorder.sessionShutdown((event as any).reason);
+    const reason = (event as any).reason;
+    recorder.sessionShutdown(reason);
+
+    if (reason === "quit" && !exitSidecarClaimed) {
+      claimExitSidecar(process.env.PI_SUBAGENT_SESSION, { type: "quit" });
+    }
   });
 
   // Toggle expand/collapse with Ctrl+J
@@ -290,7 +326,7 @@ export default function (pi: ExtensionAPI) {
         name: process.env.PI_SUBAGENT_NAME ?? "subagent",
         message: params.message,
       };
-      writeFileSync(`${sessionFile}.exit`, JSON.stringify(exitData));
+      claimExitSidecar(sessionFile, exitData);
 
       ctx.shutdown();
       return {
@@ -311,9 +347,7 @@ export default function (pi: ExtensionAPI) {
     async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
       const sessionFile = process.env.PI_SUBAGENT_SESSION;
       recorder.subagentDone();
-      if (sessionFile) {
-        writeFileSync(`${sessionFile}.exit`, JSON.stringify({ type: "done" }));
-      }
+      claimExitSidecar(sessionFile, { type: "done" });
       ctx.shutdown();
       return {
         content: [{ type: "text", text: "Shutting down subagent session." }],

--- a/test/test.ts
+++ b/test/test.ts
@@ -49,10 +49,11 @@ import {
   getSubagentActivityFile,
   readSubagentActivityFile,
 } from "../pi-extension/subagents/activity.ts";
-import {
+import subagentDoneExtension, {
   shouldMarkUserTookOver,
   shouldAutoExitOnAgentEnd,
   findLatestAssistantError,
+  writeExitSidecarIfAbsent,
 } from "../pi-extension/subagents/subagent-done.ts";
 import { __pollForExitTest__ } from "../pi-extension/subagents/cmux.ts";
 
@@ -73,6 +74,15 @@ function withTempDir(run: (dir: string) => void) {
   const dir = createTestDir();
   try {
     run(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function withTempDirAsync(run: (dir: string) => Promise<void>) {
+  const dir = createTestDir();
+  try {
+    await run(dir);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -1217,6 +1227,224 @@ describe("subagent discovery", () => {
   });
 });
 describe("subagent-done.ts", () => {
+  function createMockSubagentDoneApi() {
+    const handlers = new Map<string, Function>();
+    const registeredTools: any[] = [];
+    return {
+      handlers,
+      registeredTools,
+      api: {
+        on(event: string, handler: Function) {
+          handlers.set(event, handler);
+        },
+        registerTool(tool: any) {
+          registeredTools.push(tool);
+        },
+        registerShortcut() {},
+        getAllTools() {
+          return [];
+        },
+      } as any,
+    };
+  }
+
+  describe("writeExitSidecarIfAbsent", () => {
+    it("writes a quit sidecar when no sidecar exists", () => withTempDir((dir) => {
+      const sessionFile = join(dir, "session.jsonl");
+
+      assert.equal(writeExitSidecarIfAbsent(sessionFile, { type: "quit" }), "written");
+      assert.deepEqual(JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")), { type: "quit" });
+    }));
+
+    it("does not overwrite an existing sidecar", () => withTempDir((dir) => {
+      const sessionFile = join(dir, "session.jsonl");
+      writeFileSync(`${sessionFile}.exit`, JSON.stringify({ type: "done" }));
+
+      assert.equal(writeExitSidecarIfAbsent(sessionFile, { type: "quit" }), "exists");
+      assert.deepEqual(JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")), { type: "done" });
+    }));
+
+    it("distinguishes missing session and write failures from claimed sidecars", () => withTempDir((dir) => {
+      assert.equal(writeExitSidecarIfAbsent(undefined, { type: "quit" }), "missing-session");
+      assert.equal(
+        writeExitSidecarIfAbsent(join(dir, "missing", "session.jsonl"), { type: "quit" }),
+        "write-error",
+      );
+    }));
+  });
+
+  describe("sidecar-producing shutdown paths", () => {
+    it("normal auto-exit writes a done sidecar", () => withTempDir((dir) => {
+      const previousSession = process.env.PI_SUBAGENT_SESSION;
+      const previousAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
+      const sessionFile = join(dir, "session.jsonl");
+      process.env.PI_SUBAGENT_SESSION = sessionFile;
+      process.env.PI_SUBAGENT_AUTO_EXIT = "1";
+      const { api, handlers } = createMockSubagentDoneApi();
+      let shutdownCalled = false;
+      const ctx = {
+        shutdown() {
+          assert.deepEqual(JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")), { type: "done" });
+          shutdownCalled = true;
+        },
+      };
+
+      try {
+        subagentDoneExtension(api);
+        handlers.get("agent_end")?.({ messages: [{ role: "assistant", stopReason: "stop" }] }, ctx);
+        assert.equal(shutdownCalled, true);
+        assert.deepEqual(JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")), { type: "done" });
+
+        rmSync(`${sessionFile}.exit`, { force: true });
+        handlers.get("session_shutdown")?.({ reason: "quit" });
+        assert.throws(() => readFileSync(`${sessionFile}.exit`, "utf8"), /ENOENT/);
+      } finally {
+        restoreEnvVar("PI_SUBAGENT_SESSION", previousSession);
+        restoreEnvVar("PI_SUBAGENT_AUTO_EXIT", previousAutoExit);
+      }
+    }));
+
+    it("provider-error auto-exit writes an error sidecar", () => withTempDir((dir) => {
+      const previousSession = process.env.PI_SUBAGENT_SESSION;
+      const previousAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
+      const sessionFile = join(dir, "session.jsonl");
+      process.env.PI_SUBAGENT_SESSION = sessionFile;
+      process.env.PI_SUBAGENT_AUTO_EXIT = "1";
+      const { api, handlers } = createMockSubagentDoneApi();
+      let shutdownCalled = false;
+      const expectedSidecar = {
+        type: "error",
+        errorMessage: "529 overloaded",
+        stopReason: "error",
+      };
+      const ctx = {
+        shutdown() {
+          assert.deepEqual(JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")), expectedSidecar);
+          shutdownCalled = true;
+        },
+      };
+
+      try {
+        subagentDoneExtension(api);
+        handlers.get("agent_end")?.({
+          messages: [{ role: "assistant", stopReason: "error", errorMessage: "529 overloaded" }],
+        }, ctx);
+        assert.equal(shutdownCalled, true);
+        assert.deepEqual(JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")), expectedSidecar);
+
+        rmSync(`${sessionFile}.exit`, { force: true });
+        handlers.get("session_shutdown")?.({ reason: "quit" });
+        assert.throws(() => readFileSync(`${sessionFile}.exit`, "utf8"), /ENOENT/);
+      } finally {
+        restoreEnvVar("PI_SUBAGENT_SESSION", previousSession);
+        restoreEnvVar("PI_SUBAGENT_AUTO_EXIT", previousAutoExit);
+      }
+    }));
+
+    it("session_shutdown quit writes a quit sidecar only when absent", () => withTempDir((dir) => {
+      const previousSession = process.env.PI_SUBAGENT_SESSION;
+      const sessionFile = join(dir, "session.jsonl");
+      process.env.PI_SUBAGENT_SESSION = sessionFile;
+      const { api, handlers } = createMockSubagentDoneApi();
+
+      try {
+        subagentDoneExtension(api);
+        handlers.get("session_shutdown")?.({ reason: "quit" });
+        assert.deepEqual(JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")), { type: "quit" });
+
+        writeFileSync(`${sessionFile}.exit`, JSON.stringify({ type: "done" }));
+        handlers.get("session_shutdown")?.({ reason: "quit" });
+        assert.deepEqual(JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")), { type: "done" });
+      } finally {
+        restoreEnvVar("PI_SUBAGENT_SESSION", previousSession);
+      }
+    }));
+
+    it("does not suppress quit fallback after a failed sidecar write", () => withTempDir((dir) => {
+      const previousSession = process.env.PI_SUBAGENT_SESSION;
+      const previousAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
+      const sessionDir = join(dir, "missing");
+      const sessionFile = join(sessionDir, "session.jsonl");
+      process.env.PI_SUBAGENT_SESSION = sessionFile;
+      process.env.PI_SUBAGENT_AUTO_EXIT = "1";
+      const { api, handlers } = createMockSubagentDoneApi();
+      const ctx = { shutdown() {} };
+
+      try {
+        subagentDoneExtension(api);
+        handlers.get("agent_end")?.({ messages: [{ role: "assistant", stopReason: "stop" }] }, ctx);
+
+        mkdirSync(sessionDir);
+        handlers.get("session_shutdown")?.({ reason: "quit" });
+        assert.deepEqual(JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")), { type: "quit" });
+      } finally {
+        restoreEnvVar("PI_SUBAGENT_SESSION", previousSession);
+        restoreEnvVar("PI_SUBAGENT_AUTO_EXIT", previousAutoExit);
+      }
+    }));
+
+    it("subagent_done is not reclassified as quit after the sidecar is consumed", async () => {
+      await withTempDirAsync(async (dir) => {
+        const previousSession = process.env.PI_SUBAGENT_SESSION;
+        const sessionFile = join(dir, "session.jsonl");
+        process.env.PI_SUBAGENT_SESSION = sessionFile;
+        const { api, handlers, registeredTools } = createMockSubagentDoneApi();
+        let shutdownCalled = false;
+        const ctx = { shutdown() { shutdownCalled = true; } };
+
+        try {
+          subagentDoneExtension(api);
+          const tool = registeredTools.find((registeredTool) => registeredTool.name === "subagent_done");
+          assert.ok(tool, "expected subagent_done tool to be registered");
+
+          await tool.execute("tool-call", {}, undefined, undefined, ctx);
+          assert.equal(shutdownCalled, true);
+          assert.deepEqual(JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")), { type: "done" });
+
+          rmSync(`${sessionFile}.exit`, { force: true });
+          handlers.get("session_shutdown")?.({ reason: "quit" });
+          assert.throws(() => readFileSync(`${sessionFile}.exit`, "utf8"), /ENOENT/);
+        } finally {
+          restoreEnvVar("PI_SUBAGENT_SESSION", previousSession);
+        }
+      });
+    });
+
+    it("caller_ping is not reclassified as quit after the sidecar is consumed", async () => {
+      await withTempDirAsync(async (dir) => {
+        const previousSession = process.env.PI_SUBAGENT_SESSION;
+        const previousName = process.env.PI_SUBAGENT_NAME;
+        const sessionFile = join(dir, "session.jsonl");
+        process.env.PI_SUBAGENT_SESSION = sessionFile;
+        process.env.PI_SUBAGENT_NAME = "PingWorker";
+        const { api, handlers, registeredTools } = createMockSubagentDoneApi();
+        let shutdownCalled = false;
+        const ctx = { shutdown() { shutdownCalled = true; } };
+
+        try {
+          subagentDoneExtension(api);
+          const tool = registeredTools.find((registeredTool) => registeredTool.name === "caller_ping");
+          assert.ok(tool, "expected caller_ping tool to be registered");
+
+          await tool.execute("tool-call", { message: "need help" }, undefined, undefined, ctx);
+          assert.equal(shutdownCalled, true);
+          assert.deepEqual(JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")), {
+            type: "ping",
+            name: "PingWorker",
+            message: "need help",
+          });
+
+          rmSync(`${sessionFile}.exit`, { force: true });
+          handlers.get("session_shutdown")?.({ reason: "quit" });
+          assert.throws(() => readFileSync(`${sessionFile}.exit`, "utf8"), /ENOENT/);
+        } finally {
+          restoreEnvVar("PI_SUBAGENT_SESSION", previousSession);
+          restoreEnvVar("PI_SUBAGENT_NAME", previousName);
+        }
+      });
+    });
+  });
+
   describe("shouldMarkUserTookOver", () => {
     it("ignores the initial injected task before the first agent run", () => {
       assert.equal(shouldMarkUserTookOver(false), false);
@@ -1315,6 +1543,13 @@ describe("cmux.ts interpretExitSidecar", () => {
     });
   });
 
+  it("decodes quit payloads", () => {
+    assert.deepEqual(interpretExitSidecar({ type: "quit" }), {
+      reason: "quit",
+      exitCode: 0,
+    });
+  });
+
   it("decodes error payloads and propagates the message with a non-zero exit code", () => {
     assert.deepEqual(
       interpretExitSidecar({
@@ -1367,10 +1602,20 @@ describe("tool registration", () => {
       autoExit: true,
       interactive: false,
     });
+
     assert.deepEqual(testApi.resolveResumeLaunchBehavior({ autoExit: false }), {
       autoExit: false,
       interactive: true,
     });
+  });
+
+  it("uses the quit fallback for resumed sessions without assistant output", () => {
+    const testApi = (subagentsModule as any).__test__;
+
+    assert.equal(
+      testApi.resolveResumeSummary([], { exitCode: 0, exitReason: "quit" }),
+      "Sub-agent session was closed by the user before it called subagent_done.",
+    );
   });
 
   it("expands spawning false to deny subagent interruption", () => {
@@ -1887,6 +2132,52 @@ describe("subagent interruption", () => {
     assert.match(presentation, /subagent_resume/);
     assert.match(presentation, /Resume: pi --session/);
     assert.doesNotMatch(presentation, /ignored when errorMessage is present/);
+  });
+
+  it("renders manual quit as closed by user", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const presentation = testApi.resolveResultPresentation(
+      {
+        exitCode: 0,
+        elapsed: 14,
+        exitReason: "quit",
+        summary: "Sub-agent session was closed by the user before it called subagent_done.",
+        sessionFile: "/tmp/subagent.jsonl",
+      },
+      "Worker",
+    );
+
+    assert.match(presentation, /Sub-agent "Worker" closed by user/);
+    assert.doesNotMatch(presentation, /completed/);
+    assert.match(presentation, /Resume: pi --session/);
+  });
+
+  it("uses closed by user renderer status for quit exits", () => {
+    const { api, registeredMessageRenderers } = createMockExtensionApi();
+    (subagentsModule as any).default(api);
+    const rendererEntry = registeredMessageRenderers.find((entry) => entry.name === "subagent_result");
+    assert.ok(rendererEntry, "expected subagent_result renderer to be registered");
+
+    const theme = {
+      fg(_color: string, text: string) { return text; },
+      bg(_color: string, text: string) { return text; },
+      bold(text: string) { return text; },
+    };
+    const rendered = rendererEntry.renderer(
+      {
+        customType: "subagent_result",
+        content:
+          'Sub-agent "Worker" closed by user (14s).\n\n' +
+          "Sub-agent session was closed by the user before it called subagent_done.",
+        details: { name: "Worker", exitCode: 0, elapsed: 14, exitReason: "quit" },
+      },
+      { expanded: true },
+      theme,
+    );
+
+    const output = rendered.render(100).join("\n");
+    assert.match(output, /closed by user/);
+    assert.doesNotMatch(output, /completed/);
   });
 });
 


### PR DESCRIPTION
Fixes a lifecycle gap where a Pi-backed child subagent could be manually quit while the parent kept treating it as still running.  Graceful child shutdown now uses the existing `.exit` sidecar protocol, so the watcher receives a terminal exit record and can clear parent-side state instead of relying on shell/screen sentinel behavior.

I believe the issue originates in the initial `.exit` sidecar design: `subagent_done` and `caller_ping` wrote terminal sidecars, but quitting the child session directly didn't.  https://github.com/HazAT/pi-interactive-subagents/commit/b4b02878328dfba00301efa87a0b44b0fde4e739 made that direct quit observable via `session_shutdown("quit")`; this PR wires that event into the same terminal-exit contract.

The implementation logic: child sessions classify their own exits as `done`, `ping`, `error`, or `quit`, and the parent renders manual quit as "closed by user" rather than task completion or failure.  The child-side sidecar claim is process-local and uses exclusive create semantics, so the first successful writer wins and later shutdown bookkeeping can't reclassify an already-claimed `done` / `ping` / `error` exit as a stale quit after the parent consumes the sidecar.

Summary of changes:
  - child extension: add an idempotent `.exit` sidecar writer with atomic first-writer-wins semantics
  - child extension: write `done` for normal auto-exit and preserve `error`, `ping`, and explicit `subagent_done` sidecars
  - child extension: write `quit` on unclaimed `session_shutdown("quit")` so manual child exits notify the parent
  - parent watcher: decode `{ type: "quit" }` as a terminal `quit` reason
  - parent result flow: thread `exitReason` through subagent completion, resume handling, result details, and rendering
  - UI: present manual child shutdown as "closed by user" instead of completed or failed
  - tests: cover sidecar writes, non-overwrite behavior, stale-quit race protection, quit decoding, resume fallback, and result rendering
  
Verification:
  - unit: `npm test` / `node --test test/test.ts` → 138/138 passing (with a local-only patch for a confirmed-preexisting planner fixture mismatch)
  - integration: full cmux integration suite passed with `PI_TEST_MODEL=openai-codex/gpt-5.4-mini` (I'm without Claude in Pi currently) → 15/15 passing
  - manual: spawned an `auto-exit: false` worker, quit the child with `/quit`, and confirmed the parent emitted `Sub-agent "ManualQuitCheck" closed by user`, not completed/failed
  - manual: resumed a previously completed subagent session after its sidecar had been consumed; confirmed it accepted the follow-up and did not immediately emit a stale `closed by user` result

Screenshots:
- Manually exiting subagent sessions without interrupting subagent turns:
<p align="center">
<img width="540" alt="exited manually without subagent turn interruption" src="https://github.com/user-attachments/assets/52e36a3c-8bc0-44cb-8011-218dcaed2a10" />
</p>
<br>
<p align="center">
<img width="540" alt="exited manually without subagent turn interruption" src="https://github.com/user-attachments/assets/041c453a-e74d-47ad-9449-f3c2b96d81cc" />
</p>

- Manually exiting a subagent session and, in the process of doing so, interrupting a subagent turn:
<p align="center">
<img width="550" alt="exited manually with subagent turn interruption" src="https://github.com/user-attachments/assets/f0f356f3-6ab8-48d8-b69b-23211fbc5c30" />
</p>
