### PR TITLE
feat(subagents): add Cursor Agent backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ You are a specialized agent that does X...
 | `description` | string  | Shown in `subagents_list` output                                                                                                                                                                                                                                            |
 | `model`       | string  | Default model (e.g. `anthropic/claude-sonnet-4-6`)                                                                                                                                                                                                                          |
 | `thinking`    | string  | Thinking level: `minimal`, `medium`, `high`                                                                                                                                                                                                                                 |
-| `tools`       | string  | Comma-separated **native pi tools only**: `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`                                                                                                                                                                             |
+| `tools`       | string  | Comma-separated tool allowlist. For Pi-backed agents, use native pi tool names like `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`. For Claude Code-backed agents (`cli: claude`), this is passed to Claude Code as `--tools`, so use Claude Code tool names like `Read`, `Grep`, `Glob`, `Bash`, `Edit`. |
 | `skills`      | string  | Comma-separated skill names to auto-load                                                                                                                                                                                                                                    |
 | `session-mode` | string | Default child-session mode: `standalone`, `lineage-only`, or `fork` |
 | `spawning`    | boolean | Set `false` to deny all subagent-spawning tools                                                                                                                                                                                                                             |
@@ -305,6 +305,13 @@ You are a specialized agent that does X...
 | `auto-exit`   | boolean | Auto-shutdown when the agent finishes its turn — no `subagent_done` call needed. If the user sends any input, auto-exit is permanently disabled and the user takes over the session. Recommended for autonomous agents (scout, worker); not for interactive ones (planner). Also determines the default value of `interactive` (see below). |
 | `interactive` | boolean | derived        | Override whether stall/recovery transitions wake the parent session. Defaults to the inverse of `auto-exit`: autonomous agents (`auto-exit: true`) are non-interactive and get stall pings; agents without `auto-exit` are interactive and stay quiet. Explicit values take precedence. |
 | `cwd`         | string  | Default working directory (absolute or relative to project root)                                                                                                                                                                                                            |
+| `cli`         | string  | Optional backend CLI. Set `claude` to launch Claude Code instead of Pi for this agent.                                                                                                                                                                                      |
+| `permission-mode` | string | Claude Code only. Passed as `claude --permission-mode <mode>`. If unset for `cli: claude`, the launcher keeps the legacy `--dangerously-skip-permissions` behavior.                                                                                                      |
+| `claude-permission-mode` | string | Claude Code only. Explicit alias for `permission-mode`.                                                                                                                                                                                                          |
+| `allowed-tools` | string | Claude Code only. Alias for `tools`, passed as `claude --tools <tools>`.                                                                                                                                                                                                     |
+| `claude-tools` | string | Claude Code only. Explicit alias for `tools`, passed as `claude --tools <tools>`.                                                                                                                                                                                           |
+| `disallowed-tools` | string | Claude Code only. Passed as `claude --disallowed-tools <tools>`.                                                                                                                                                                                                      |
+| `claude-disallowed-tools` | string | Claude Code only. Explicit alias for `disallowed-tools`.                                                                                                                                                                                                        |
 | `disable-model-invocation` | boolean | Hide this agent from discovery surfaces like `subagents_list`. The agent still remains directly invokable by explicit name via `subagent({ agent: "name", ... })`. |
 
 ---
@@ -377,6 +384,127 @@ Or per spawn:
 ```typescript
 subagent({ name: "Scout", agent: "scout", interactive: true, task: "..." });
 ```
+
+### Claude Code agents and read-only mode
+
+Agents with `cli: claude` launch Claude Code instead of Pi. This is useful when you want a subagent to use a local Claude Code installation while still being spawned and monitored by this extension.
+
+If a Claude Code agent does not set `permission-mode`, the launcher preserves the bundled `claude-code` behavior and starts Claude Code with `--dangerously-skip-permissions`. To make the default `claude-code` agent safer, override that bundled agent by creating a same-name file in `.pi/agents/claude-code.md` or `~/.pi/agent/agents/claude-code.md` and set Claude Code's permission and tool flags there.
+
+Recommended guidelines:
+
+- Do not edit the bundled `agents/claude-code.md` just to change permissions. Override it with a same-name project-local or global agent file.
+- Use Claude Code tool names, not Pi tool names, for Claude Code agents. Examples: `Read`, `Grep`, `Glob`, `Bash`, `Edit`, `Write`.
+- For read-only investigation, allow only read-oriented Claude Code tools and deny mutation or shell tools.
+- Use `spawning: false` and `deny-tools: claude` when the child should not delegate or call back into Claude Code from Pi tools.
+- Keep `auto-exit: true` for autonomous read-only investigations so the pane closes and reports back when done.
+
+Global override example (`~/.pi/agent/agents/claude-code.md`):
+
+```markdown
+---
+name: claude-code
+description: Read-only Claude Code session for investigation and code exploration
+cli: claude
+model: sonnet
+auto-exit: true
+spawning: false
+deny-tools: claude
+claude-permission-mode: default
+claude-tools: Read,Grep,Glob
+claude-disallowed-tools: Bash,Edit,Write
+---
+
+# Claude Code Read-only
+
+You are a read-only Claude Code session spawned by pi for investigation and code exploration.
+
+You may inspect files with Read, Grep, and Glob. Do not edit files, run shell commands, change repository state, install packages, run tests, or make network calls.
+
+## Guidelines
+
+- Focus on the task given to you.
+- Report concrete findings with evidence, including file paths and relevant excerpts.
+- If you need information that requires shell commands, edits, builds, tests, or network access, explain what is needed instead of attempting it.
+- Your final message should summarize what you found and what you could not verify under read-only constraints.
+```
+
+Then keep using the normal bundled agent name. Agent discovery gives your global or project-local file precedence over the package-bundled definition:
+
+```typescript
+subagent({
+  name: "Read-only investigation",
+  agent: "claude-code",
+  task: "Inspect the auth flow and report where session cookies are created.",
+});
+```
+
+The extension passes the Claude-prefixed fields through to Claude Code as:
+
+```bash
+claude --permission-mode default --tools Read,Grep,Glob --disallowed-tools Bash,Edit,Write
+```
+
+### Cursor Agent agents and read-only mode
+
+Agents with `cli: cursor` launch Cursor Agent instead of Pi. This is useful when you want a subagent to use a local Cursor Agent installation while still being spawned and monitored by this extension.
+
+The bundled `cursor-agent` agent is intentionally autonomous and starts Cursor Agent with `--yolo` via `cursor-yolo: true`. Its bundled model is `composer-2`. To make the default `cursor-agent` safer, override that bundled agent by creating a same-name file in `.pi/agents/cursor-agent.md` or `~/.pi/agent/agents/cursor-agent.md` and set Cursor Agent's mode and permission flags there.
+
+Recommended guidelines:
+
+- Do not edit the bundled `agents/cursor-agent.md` just to change permissions. Override it with a same-name project-local or global agent file.
+- Use Cursor Agent CLI flags through Cursor-prefixed frontmatter. Examples: `cursor-mode: plan`, `cursor-force: false`, `cursor-yolo: true`, `cursor-sandbox: enabled`.
+- For read-only investigation, use `cursor-mode: plan` and `cursor-force: false`.
+- Use `spawning: false` and `deny-tools: cursor` when the child should not delegate or call back into Cursor Agent from Pi tools.
+- Keep `auto-exit: true` for autonomous read-only investigations so the pane closes and reports back when done.
+
+Global override example (`~/.pi/agent/agents/cursor-agent.md`):
+
+```markdown
+---
+name: cursor-agent
+description: Read-only Cursor Agent session for investigation and planning
+cli: cursor
+model: composer-2
+cursor-mode: plan
+cursor-force: false
+auto-exit: true
+spawning: false
+deny-tools: cursor
+---
+
+# Cursor Agent Read-only
+
+You are a read-only Cursor Agent session spawned by pi for investigation and planning.
+
+Do not edit files. Do not run commands that modify files, state, dependencies, git history, services, databases, or external systems.
+
+## Guidelines
+
+- Focus on the task given to you.
+- Inspect the codebase and report concrete findings with evidence, including file paths and relevant excerpts.
+- If you need information that requires edits, builds, tests, shell commands with side effects, or network access, explain what is needed instead of attempting it.
+- Your final message should summarize what you found and what you could not verify under read-only constraints.
+```
+
+Then keep using the normal bundled agent name. Agent discovery gives your global or project-local file precedence over the package-bundled definition:
+
+```typescript
+subagent({
+  name: "Read-only Cursor investigation",
+  agent: "cursor-agent",
+  task: "Inspect the auth flow and report where session cookies are created.",
+});
+```
+
+The extension passes the Cursor-prefixed fields through to Cursor Agent as:
+
+```bash
+agent --mode plan
+```
+
+For Cursor Agent completion detection, the extension temporarily merges a guarded stop hook into `~/.cursor/hooks.json` while a Cursor-backed subagent is running. The hook exits immediately unless `PI_CURSOR_SENTINEL` is set, and the extension removes its hook entry after the last Cursor-backed subagent exits.
 
 ---
 

--- a/agents/cursor-agent.md
+++ b/agents/cursor-agent.md
@@ -1,0 +1,24 @@
+---
+name: cursor-agent
+description: Self-driving Cursor Agent session for deep investigation, experimentation, and code exploration
+cli: cursor
+model: composer-2
+cursor-yolo: true
+auto-exit: true
+spawning: false
+deny-tools: cursor
+---
+
+# Cursor Agent
+
+You are a self-driving Cursor Agent session spawned by pi for hands-on investigation and experimentation.
+
+You have full autonomy: shell commands, file access, git clone, code editing, running tests, building projects, and anything a developer can do in a terminal.
+
+## Guidelines
+
+- Focus on the task given to you
+- Be thorough in your investigation
+- Report concrete findings with evidence (file paths, command output, test results)
+- If you get stuck, explain what you tried and what failed
+- Your final message should summarize what you accomplished and what you found

--- a/pi-extension/subagents/cursor-hooks/on-stop.sh
+++ b/pi-extension/subagents/cursor-hooks/on-stop.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Stop hook for pi-spawned Cursor Agent sessions.
+# pi-interactive-subagents cursor stop hook
+
+set -euo pipefail
+
+# Read JSON input from stdin.
+input=$(cat)
+
+# Guard: only act for pi-spawned Cursor Agent sessions.
+if [ -z "${PI_CURSOR_SENTINEL:-}" ]; then
+  exit 0
+fi
+
+# Guard: if stop_hook_active is ever provided, do not recurse.
+stop_hook_active=$(echo "$input" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('stop_hook_active', False))" 2>/dev/null || echo "False")
+if [ "$stop_hook_active" = "True" ]; then
+  exit 0
+fi
+
+status=$(echo "$input" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status') or 'completed')" 2>/dev/null || echo "completed")
+transcript_path=$(echo "$input" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('transcript_path') or '')" 2>/dev/null || echo "")
+
+# Always write transcript path so the watcher can copy the session file.
+if [ -n "$transcript_path" ]; then
+  echo "$transcript_path" > "${PI_CURSOR_SENTINEL}.transcript" 2>/dev/null || true
+fi
+
+# The stop hook does not expose the final assistant message. For successful runs,
+# create an empty sentinel so pi falls back to the pane screen scrape. For failed
+# or aborted runs, write a concise status summary.
+if [ "$status" = "completed" ]; then
+  : > "$PI_CURSOR_SENTINEL" 2>/dev/null || touch "$PI_CURSOR_SENTINEL"
+else
+  echo "Cursor Agent stopped with status: $status" > "$PI_CURSOR_SENTINEL" 2>/dev/null || touch "$PI_CURSOR_SENTINEL"
+fi
+
+exit 0

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -12,6 +12,9 @@ import {
   mkdirSync,
   copyFileSync,
   unlinkSync,
+  chmodSync,
+  renameSync,
+  rmSync,
 } from "node:fs";
 import { homedir } from "node:os";
 import {
@@ -124,7 +127,7 @@ const SubagentParams = Type.Object({
   resumeSessionId: Type.Optional(
     Type.String({
       description:
-        "Resume a previous Claude Code session by its ID. Loads the conversation history and continues where it left off. The session ID is returned in details of every claude tool call. Use this to retry cancelled runs or ask follow-up questions.",
+        "Resume a previous Claude Code or Cursor Agent session by its ID. Loads the conversation history and continues where it left off. The session ID is returned in result details when available. Use this to retry cancelled runs or ask follow-up questions.",
     }),
   ),
 });
@@ -137,6 +140,13 @@ interface AgentDefaults {
   skills?: string;
   thinking?: string;
   denyTools?: string;
+  claudePermissionMode?: string;
+  claudeAllowedTools?: string;
+  claudeDisallowedTools?: string;
+  cursorForce?: boolean;
+  cursorYolo?: boolean;
+  cursorMode?: string;
+  cursorSandbox?: string;
   spawning?: boolean;
   autoExit?: boolean;
   interactive?: boolean;
@@ -242,6 +252,20 @@ function parseAgentDefinition(content: string, fallbackName: string): AgentDefin
     skills: getFrontmatterValue(frontmatter, "skill") ?? getFrontmatterValue(frontmatter, "skills"),
     thinking: getFrontmatterValue(frontmatter, "thinking"),
     denyTools: getFrontmatterValue(frontmatter, "deny-tools"),
+    claudePermissionMode:
+      getFrontmatterValue(frontmatter, "claude-permission-mode") ??
+      getFrontmatterValue(frontmatter, "permission-mode"),
+    claudeAllowedTools:
+      getFrontmatterValue(frontmatter, "claude-tools") ??
+      getFrontmatterValue(frontmatter, "allowed-tools") ??
+      getFrontmatterValue(frontmatter, "tools"),
+    claudeDisallowedTools:
+      getFrontmatterValue(frontmatter, "claude-disallowed-tools") ??
+      getFrontmatterValue(frontmatter, "disallowed-tools"),
+    cursorForce: parseOptionalBoolean(getFrontmatterValue(frontmatter, "cursor-force")),
+    cursorYolo: parseOptionalBoolean(getFrontmatterValue(frontmatter, "cursor-yolo")),
+    cursorMode: getFrontmatterValue(frontmatter, "cursor-mode"),
+    cursorSandbox: getFrontmatterValue(frontmatter, "cursor-sandbox"),
     spawning: parseOptionalBoolean(getFrontmatterValue(frontmatter, "spawning")),
     autoExit: parseOptionalBoolean(getFrontmatterValue(frontmatter, "auto-exit")),
     interactive: parseOptionalBoolean(getFrontmatterValue(frontmatter, "interactive")),
@@ -475,6 +499,7 @@ interface SubagentResult {
   summary: string;
   sessionFile?: string;
   claudeSessionId?: string;
+  cursorSessionId?: string;
   exitCode: number;
   elapsed: number;
   error?: string;
@@ -686,6 +711,51 @@ function buildSubagentToolAllowlist(effectiveTools?: string): string | null {
   return [...allow].join(",");
 }
 
+function buildClaudePermissionArgs(agentDefs: AgentDefaults | null): string[] {
+  const args: string[] = [];
+  const permissionMode = agentDefs?.claudePermissionMode?.trim();
+
+  if (permissionMode) {
+    args.push("--permission-mode", shellEscape(permissionMode));
+  } else {
+    args.push("--dangerously-skip-permissions");
+  }
+
+  const allowedTools = agentDefs?.claudeAllowedTools?.trim();
+  if (allowedTools) {
+    args.push("--tools", shellEscape(allowedTools));
+  }
+
+  const disallowedTools = agentDefs?.claudeDisallowedTools?.trim();
+  if (disallowedTools) {
+    args.push("--disallowed-tools", shellEscape(disallowedTools));
+  }
+
+  return args;
+}
+
+function buildCursorPermissionArgs(agentDefs: AgentDefaults | null): string[] {
+  const args: string[] = [];
+  const mode = agentDefs?.cursorMode?.trim();
+
+  if (mode === "plan" || mode === "ask") {
+    args.push("--mode", shellEscape(mode));
+  }
+
+  if (agentDefs?.cursorYolo) {
+    args.push("--yolo");
+  } else if (agentDefs?.cursorForce === true || (!mode && agentDefs?.cursorForce !== false)) {
+    args.push("--force");
+  }
+
+  const sandbox = agentDefs?.cursorSandbox?.trim();
+  if (sandbox === "enabled" || sandbox === "disabled") {
+    args.push("--sandbox", shellEscape(sandbox));
+  }
+
+  return args;
+}
+
 function buildPiPromptArgs(params: {
   effectiveSkills?: string;
   taskDelivery: "direct" | "artifact";
@@ -706,6 +776,177 @@ function buildPiPromptArgs(params: {
   ];
 }
 
+const CURSOR_HOOK_COMMAND = "./hooks/pi-interactive-subagents-stop.sh";
+const CURSOR_HOOK_MARKER = "pi-interactive-subagents cursor stop hook";
+const CURSOR_HOOK_STALE_MS = 12 * 60 * 60 * 1000;
+
+function getCursorConfigDir(): string {
+  return process.env.PI_CURSOR_CONFIG_DIR ?? join(homedir(), ".cursor");
+}
+
+function getCursorHookStateDir(): string {
+  return join(getAgentConfigDir(), "cursor-hook");
+}
+
+function getCursorHookPaths() {
+  const cursorDir = getCursorConfigDir();
+  const stateDir = getCursorHookStateDir();
+  return {
+    cursorDir,
+    hooksJson: join(cursorDir, "hooks.json"),
+    hookScript: join(cursorDir, "hooks", "pi-interactive-subagents-stop.sh"),
+    hookSource: join(SUBAGENTS_DIR, "cursor-hooks", "on-stop.sh"),
+    lockDir: join(stateDir, "install.lock"),
+    leasesDir: join(stateDir, "leases"),
+  };
+}
+
+type CursorHooksConfig = {
+  version?: number;
+  hooks?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+function ensureCursorHookConfig(config: CursorHooksConfig): CursorHooksConfig {
+  const next: CursorHooksConfig = { ...config };
+  next.version = typeof next.version === "number" ? next.version : 1;
+
+  const hooks = next.hooks && typeof next.hooks === "object" && !Array.isArray(next.hooks)
+    ? { ...next.hooks }
+    : {};
+  const stop = hooks.stop;
+  if (stop != null && !Array.isArray(stop)) {
+    throw new Error("Cursor hooks.json has a non-array hooks.stop field");
+  }
+
+  const stopHooks = Array.isArray(stop) ? [...stop] : [];
+  const alreadyInstalled = stopHooks.some((hook) =>
+    hook && typeof hook === "object" && (hook as { command?: unknown }).command === CURSOR_HOOK_COMMAND
+  );
+  if (!alreadyInstalled) {
+    stopHooks.push({ command: CURSOR_HOOK_COMMAND, timeout: 10 });
+  }
+
+  hooks.stop = stopHooks;
+  next.hooks = hooks;
+  return next;
+}
+
+function removeCursorHookConfig(config: CursorHooksConfig): CursorHooksConfig {
+  const hooks = config.hooks && typeof config.hooks === "object" && !Array.isArray(config.hooks)
+    ? { ...config.hooks }
+    : null;
+  if (!hooks) return config;
+
+  const stop = hooks.stop;
+  if (Array.isArray(stop)) {
+    const remaining = stop.filter((hook) =>
+      !(hook && typeof hook === "object" && (hook as { command?: unknown }).command === CURSOR_HOOK_COMMAND)
+    );
+    if (remaining.length > 0) hooks.stop = remaining;
+    else delete hooks.stop;
+  }
+
+  return { ...config, hooks };
+}
+
+function readCursorHooksConfig(hooksJson: string): CursorHooksConfig {
+  if (!existsSync(hooksJson)) return { version: 1, hooks: {} };
+  const parsed = JSON.parse(readFileSync(hooksJson, "utf8"));
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Cursor hooks.json must contain a JSON object");
+  }
+  return parsed as CursorHooksConfig;
+}
+
+function writeCursorHooksConfig(hooksJson: string, config: CursorHooksConfig) {
+  mkdirSync(dirname(hooksJson), { recursive: true });
+  const tmp = `${hooksJson}.tmp-${process.pid}`;
+  writeFileSync(tmp, JSON.stringify(config, null, 2) + "\n", "utf8");
+  renameSync(tmp, hooksJson);
+}
+
+function pruneCursorHookLeases(leasesDir: string, now = Date.now()) {
+  if (!existsSync(leasesDir)) return;
+  for (const entry of readdirSync(leasesDir)) {
+    if (!entry.endsWith(".json")) continue;
+    const path = join(leasesDir, entry);
+    try {
+      const lease = JSON.parse(readFileSync(path, "utf8"));
+      const startedAt = typeof lease.startedAtMs === "number" ? lease.startedAtMs : 0;
+      if (startedAt > 0 && now - startedAt < CURSOR_HOOK_STALE_MS) continue;
+    } catch {}
+    try { unlinkSync(path); } catch {}
+  }
+}
+
+function countCursorHookLeases(leasesDir: string): number {
+  if (!existsSync(leasesDir)) return 0;
+  return readdirSync(leasesDir).filter((entry) => entry.endsWith(".json")).length;
+}
+
+async function withCursorHookLock<T>(fn: () => T | Promise<T>): Promise<T> {
+  const { lockDir } = getCursorHookPaths();
+  mkdirSync(dirname(lockDir), { recursive: true });
+
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      mkdirSync(lockDir);
+      try {
+        return await fn();
+      } finally {
+        rmSync(lockDir, { recursive: true, force: true });
+      }
+    } catch (error: any) {
+      if (error?.code !== "EEXIST") throw error;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+
+  throw new Error("Timed out waiting for Cursor hook install lock");
+}
+
+async function installCursorHookForRun(id: string, sentinelFile: string) {
+  await withCursorHookLock(() => {
+    const paths = getCursorHookPaths();
+    pruneCursorHookLeases(paths.leasesDir);
+
+    mkdirSync(dirname(paths.hookScript), { recursive: true });
+    copyFileSync(paths.hookSource, paths.hookScript);
+    chmodSync(paths.hookScript, 0o755);
+
+    const config = ensureCursorHookConfig(readCursorHooksConfig(paths.hooksJson));
+    writeCursorHooksConfig(paths.hooksJson, config);
+
+    mkdirSync(paths.leasesDir, { recursive: true });
+    writeFileSync(
+      join(paths.leasesDir, `${id}.json`),
+      JSON.stringify({ id, sentinelFile, startedAtMs: Date.now() }, null, 2) + "\n",
+      "utf8",
+    );
+  });
+}
+
+async function uninstallCursorHookForRun(id: string) {
+  await withCursorHookLock(() => {
+    const paths = getCursorHookPaths();
+    try { unlinkSync(join(paths.leasesDir, `${id}.json`)); } catch {}
+    pruneCursorHookLeases(paths.leasesDir);
+    if (countCursorHookLeases(paths.leasesDir) > 0) return;
+
+    if (existsSync(paths.hooksJson)) {
+      const config = removeCursorHookConfig(readCursorHooksConfig(paths.hooksJson));
+      writeCursorHooksConfig(paths.hooksJson, config);
+    }
+
+    try {
+      if (existsSync(paths.hookScript) && readFileSync(paths.hookScript, "utf8").includes(CURSOR_HOOK_MARKER)) {
+        unlinkSync(paths.hookScript);
+      }
+    } catch {}
+  });
+}
+
 function activityLabel(activity: SubagentActivityState): string | undefined {
   if (activity.phase !== "active") return undefined;
   if (activity.activeScope === "tool") return activity.toolName ?? "tool";
@@ -715,7 +956,7 @@ function activityLabel(activity: SubagentActivityState): string | undefined {
 }
 
 function observeRunningSubagent(running: RunningSubagent, observedAt = Date.now()) {
-  if (running.cli === "claude") return;
+  if (running.cli === "claude" || running.cli === "cursor") return;
 
   const activityFile = running.activityFile;
   const read: ActivityReadResult = activityFile
@@ -902,7 +1143,12 @@ export const __test__ = {
   resolveLaunchBehavior,
   resolveEffectiveInteractive,
   buildSubagentToolAllowlist,
+  buildClaudePermissionArgs,
+  buildCursorPermissionArgs,
   buildPiPromptArgs,
+  ensureCursorHookConfig,
+  removeCursorHookConfig,
+  extractCursorSummaryFromTranscriptPath,
   formatWidgetRightLabel,
   observeRunningSubagent,
   resolveDenyTools,
@@ -1014,7 +1260,7 @@ async function launchSubagent(
     const cmdParts: string[] = [];
     cmdParts.push(`PI_CLAUDE_SENTINEL=${shellEscape(sentinelFile)}`);
     cmdParts.push("claude");
-    cmdParts.push("--dangerously-skip-permissions");
+    cmdParts.push(...buildClaudePermissionArgs(agentDefs));
 
     if (existsSync(pluginDir)) {
       cmdParts.push("--plugin-dir", shellEscape(pluginDir));
@@ -1071,6 +1317,84 @@ async function launchSubagent(
       interactive: effectiveInteractive,
       statusState: createStatusState({
         source: "claude",
+        startTimeMs: startTime,
+      }),
+    };
+
+    runningSubagents.set(id, running);
+    return running;
+  }
+
+  // ── Cursor Agent CLI path ──
+  if (agentDefs?.cli === "cursor") {
+    const sentinelFile = `/tmp/pi-cursor-${id}-done`;
+
+    try {
+      await installCursorHookForRun(id, sentinelFile);
+    } catch (error) {
+      try { closeSurface(surface); } catch {}
+      throw error;
+    }
+
+    const cmdParts: string[] = [];
+    cmdParts.push(`PI_CURSOR_SENTINEL=${shellEscape(sentinelFile)}`);
+    cmdParts.push("agent");
+    cmdParts.push(...buildCursorPermissionArgs(agentDefs));
+
+    if (effectiveModel) {
+      cmdParts.push("--model", shellEscape(effectiveModel));
+    }
+
+    if (params.resumeSessionId) {
+      cmdParts.push("--resume", shellEscape(params.resumeSessionId));
+    }
+
+    const cursorIdentity = identity ? `\n\n${identity}` : "";
+    const cursorTask = inheritsConversationContext
+      ? params.task
+      : `${cursorIdentity}\n\n${modeHint}\n\n${params.task}\n\n${summaryInstruction}`;
+    cmdParts.push(shellEscape(cursorTask));
+
+    const cdPrefix = effectiveCwd ? `cd ${shellEscape(effectiveCwd)} && ` : "";
+    const command = `${cdPrefix}${cmdParts.join(" ")}; echo '__SUBAGENT_DONE_'$?'__'`;
+
+    const launchScriptName = `${(params.name || "subagent")
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, "")
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "") || "subagent"}-${id}.sh`;
+    const launchScriptFile = join(artifactDir, "subagent-scripts", launchScriptName);
+
+    try {
+      sendLongCommand(surface, command, {
+        scriptPath: launchScriptFile,
+        scriptPreamble: [
+          `# Cursor Agent subagent launch script for ${params.name}`,
+          `# Generated: ${new Date().toISOString()}`,
+          `# Surface: ${surface}`,
+        ].join("\n"),
+      });
+    } catch (error) {
+      await uninstallCursorHookForRun(id);
+      try { closeSurface(surface); } catch {}
+      throw error;
+    }
+
+    const running: RunningSubagent = {
+      id,
+      name: params.name,
+      task: params.task,
+      agent: params.agent,
+      surface,
+      startTime,
+      sessionFile: subagentSessionFile,
+      launchScriptFile,
+      cli: "cursor",
+      sentinelFile,
+      interactive: effectiveInteractive,
+      statusState: createStatusState({
+        source: "cursor",
         startTimeMs: startTime,
       }),
     };
@@ -1226,21 +1550,96 @@ const CLAUDE_SESSIONS_DIR = join(
   process.env.HOME ?? "/tmp",
   ".pi", "agent", "sessions", "claude-code",
 );
+const CURSOR_SESSIONS_DIR = join(
+  process.env.HOME ?? "/tmp",
+  ".pi", "agent", "sessions", "cursor-agent",
+);
 
-function copyClaudeSession(sentinelFile: string): string | null {
+function getTranscriptPathFromSentinel(sentinelFile: string): string | null {
   try {
     const transcriptFile = sentinelFile + ".transcript";
     if (!existsSync(transcriptFile)) return null;
     const transcriptPath = readFileSync(transcriptFile, "utf-8").trim();
-    if (!transcriptPath || !existsSync(transcriptPath)) return null;
-    mkdirSync(CLAUDE_SESSIONS_DIR, { recursive: true });
-    const filename = transcriptPath.split("/").pop() ?? `claude-${Date.now()}.jsonl`;
-    const dest = join(CLAUDE_SESSIONS_DIR, filename);
+    return transcriptPath && existsSync(transcriptPath) ? transcriptPath : null;
+  } catch {
+    return null;
+  }
+}
+
+function copyTranscriptSession(sentinelFile: string, sessionsDir: string, fallbackPrefix: string): string | null {
+  try {
+    const transcriptPath = getTranscriptPathFromSentinel(sentinelFile);
+    if (!transcriptPath) return null;
+    mkdirSync(sessionsDir, { recursive: true });
+    const filename = transcriptPath.split("/").pop() ?? `${fallbackPrefix}-${Date.now()}`;
+    const dest = join(sessionsDir, filename);
     copyFileSync(transcriptPath, dest);
     return filename;
   } catch {
     return null;
   }
+}
+
+function copyClaudeSession(sentinelFile: string): string | null {
+  return copyTranscriptSession(sentinelFile, CLAUDE_SESSIONS_DIR, "claude");
+}
+
+function copyCursorSession(sentinelFile: string): string | null {
+  return copyTranscriptSession(sentinelFile, CURSOR_SESSIONS_DIR, "cursor");
+}
+
+function cursorTranscriptTextParts(content: unknown): string[] {
+  if (!Array.isArray(content)) return [];
+  return content
+    .map((part) => {
+      if (!part || typeof part !== "object") return "";
+      const value = (part as { text?: unknown }).text;
+      return typeof value === "string" ? value.trim() : "";
+    })
+    .filter((text) => text && text !== "[REDACTED]");
+}
+
+function extractCursorSummaryFromTranscriptPath(transcriptPath: string): string | null {
+  let lastPlan: string | null = null;
+  let lastAssistantText: string | null = null;
+
+  try {
+    for (const line of readFileSync(transcriptPath, "utf8").split("\n")) {
+      if (!line.trim()) continue;
+      let entry: any;
+      try {
+        entry = JSON.parse(line);
+      } catch {
+        continue;
+      }
+
+      const content = entry?.message?.content;
+      if (!Array.isArray(content)) continue;
+
+      if (entry?.role === "assistant") {
+        const text = cursorTranscriptTextParts(content).join("\n\n").trim();
+        if (text) lastAssistantText = text;
+      }
+
+      for (const part of content) {
+        if (!part || typeof part !== "object") continue;
+        const tool = part as { type?: unknown; name?: unknown; input?: { plan?: unknown } };
+        if (tool.type === "tool_use" && tool.name === "CreatePlan" && typeof tool.input?.plan === "string") {
+          const plan = tool.input.plan.trim();
+          if (plan) lastPlan = plan;
+        }
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  return lastPlan ?? lastAssistantText;
+}
+
+function extractCursorSummaryFromTranscript(sentinelFile: string): string | null {
+  const transcriptPath = getTranscriptPathFromSentinel(sentinelFile);
+  return transcriptPath ? extractCursorSummaryFromTranscriptPath(transcriptPath) : null;
 }
 
 async function watchSubagent(
@@ -1297,6 +1696,46 @@ async function watchSubagent(
       return { name, task, summary, exitCode: result.exitCode, elapsed, ...(sessionId ? { claudeSessionId: sessionId } : {}) };
     }
 
+    if (running.cli === "cursor") {
+      // Cursor Agent result extraction
+      let summary = "";
+
+      if (running.sentinelFile) {
+        try {
+          summary = readFileSync(running.sentinelFile, "utf-8").trim();
+        } catch {}
+      }
+
+      if (!summary && running.sentinelFile) {
+        summary = extractCursorSummaryFromTranscript(running.sentinelFile) ?? "";
+      }
+
+      if (!summary) {
+        summary = readScreen(surface, 200)
+          .replace(/__SUBAGENT_DONE_\d+__/, "")
+          .trimEnd();
+      }
+
+      if (!summary) {
+        summary = result.exitCode !== 0
+          ? `Cursor Agent exited with code ${result.exitCode}`
+          : "Cursor Agent exited without output";
+      }
+
+      let sessionId: string | null = null;
+      if (running.sentinelFile) {
+        sessionId = copyCursorSession(running.sentinelFile);
+        try { unlinkSync(running.sentinelFile); } catch {}
+        try { unlinkSync(running.sentinelFile + ".transcript"); } catch {}
+      }
+      try { await uninstallCursorHookForRun(running.id); } catch {}
+
+      closeSurface(surface);
+      runningSubagents.delete(running.id);
+
+      return { name, task, summary, exitCode: result.exitCode, elapsed, ...(sessionId ? { cursorSessionId: sessionId } : {}) };
+    }
+
     // Pi subagent result extraction
     let summary: string;
     if (existsSync(sessionFile)) {
@@ -1330,6 +1769,9 @@ async function watchSubagent(
       ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
     };
   } catch (err: any) {
+    if (running.cli === "cursor") {
+      try { await uninstallCursorHookForRun(running.id); } catch {}
+    }
     try {
       closeSurface(surface);
     } catch {}
@@ -1499,6 +1941,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
                   sessionFile: result.sessionFile,
                   ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
                   ...(result.claudeSessionId ? { claudeSessionId: result.claudeSessionId } : {}),
+                  ...(result.cursorSessionId ? { cursorSessionId: result.cursorSessionId } : {}),
                 },
               },
               { triggerTurn: true, deliverAs: "steer" },

--- a/pi-extension/subagents/status.ts
+++ b/pi-extension/subagents/status.ts
@@ -12,7 +12,7 @@ const DEFAULT_STATUS_CONFIG_PATH = join(PACKAGE_ROOT, "config.json");
 const STATUS_CONFIG_EXAMPLE_PATH = join(PACKAGE_ROOT, "config.json.example");
 
 export type SubagentStatusKind = "starting" | "active" | "waiting" | "stalled" | "running";
-export type SubagentStatusSource = "pi" | "claude";
+export type SubagentStatusSource = "pi" | "claude" | "cursor";
 export type SubagentStatusTransition = "stalled" | "recovered" | null;
 export type StatusSnapshotState = "unseen" | "present" | "missing" | "invalid" | "wrong-id";
 export type StatusActivityPhase = "starting" | "active" | "waiting" | "done";
@@ -202,7 +202,7 @@ export function createStatusState(params: {
   source: SubagentStatusSource;
   startTimeMs: number;
 }): SubagentStatusState {
-  const initialKind = params.source === "claude" ? "running" : "starting";
+  const initialKind = params.source === "pi" ? "starting" : "running";
   return {
     source: params.source,
     startTimeMs: params.startTimeMs,
@@ -218,7 +218,7 @@ export function createStatusState(params: {
     phase: null,
     latestEvent: null,
     activityLabel: null,
-    snapshotState: params.source === "claude" ? "unseen" : "unseen",
+    snapshotState: "unseen",
     snapshotProblemSinceMs: null,
     snapshotError: null,
     currentKind: initialKind,
@@ -230,7 +230,7 @@ export function observeStatus(
   observation: StatusObservation,
   now: number,
 ): SubagentStatusState {
-  if (state.source === "claude") return state;
+  if (state.source !== "pi") return state;
 
   if (observation.snapshot !== "present") {
     return {
@@ -288,7 +288,7 @@ export function observeStatus(
 }
 
 export function forceStatusAfterInterrupt(state: SubagentStatusState, now: number): SubagentStatusState {
-  if (state.source === "claude") return state;
+  if (state.source !== "pi") return state;
 
   return {
     ...state,
@@ -340,7 +340,7 @@ export function classifyStatus(state: SubagentStatusState, now: number): StatusS
   const elapsedMs = Math.max(0, now - state.startTimeMs);
   const elapsedText = formatElapsedDuration(elapsedMs);
 
-  if (state.source === "claude") {
+  if (state.source !== "pi") {
     return {
       kind: "running",
       elapsedMs,

--- a/test/test.ts
+++ b/test/test.ts
@@ -617,6 +617,14 @@ describe("status.ts", () => {
     assert.equal(snapshot.elapsedText, "2m");
   });
 
+  it("uses elapsed-only fallback for cursor-backed subagents", () => {
+    const state = createStatusState({ source: "cursor", startTimeMs: 0 });
+    const snapshot = classifyStatus(state, 125_000);
+
+    assert.equal(snapshot.kind, "running");
+    assert.equal(snapshot.elapsedText, "2m");
+  });
+
   it("detects stalled transitions and recovery", () => {
     let state = createStatusState({ source: "pi", startTimeMs: 0 });
     state = observeStatus(state, { snapshot: "missing" }, 1_000);
@@ -884,6 +892,53 @@ describe("subagent discovery", () => {
     });
   });
 
+  it("loads Claude Code permission and tool overrides from frontmatter", async () => {
+    await withIsolatedAgentEnv(async ({ projectAgentsDir }) => {
+      writeAgentFile(
+        projectAgentsDir,
+        "claude-readonly-test-agent",
+        [
+          "name: claude-readonly-test-agent",
+          "cli: claude",
+          "permission-mode: default",
+          "tools: Read,Grep,Glob",
+          "disallowed-tools: Bash,Edit,Write",
+        ].join("\n"),
+      );
+
+      const loaded = testApi.loadAgentDefaults("claude-readonly-test-agent");
+      assert.ok(loaded, "expected agent to load");
+      assert.equal(loaded.claudePermissionMode, "default");
+      assert.equal(loaded.claudeAllowedTools, "Read,Grep,Glob");
+      assert.equal(loaded.claudeDisallowedTools, "Bash,Edit,Write");
+    });
+  });
+
+  it("loads Cursor Agent flags from frontmatter", async () => {
+    await withIsolatedAgentEnv(async ({ projectAgentsDir }) => {
+      writeAgentFile(
+        projectAgentsDir,
+        "cursor-test-agent",
+        [
+          "name: cursor-test-agent",
+          "cli: cursor",
+          "cursor-force: false",
+          "cursor-yolo: true",
+          "cursor-mode: plan",
+          "cursor-sandbox: disabled",
+        ].join("\n"),
+      );
+
+      const loaded = testApi.loadAgentDefaults("cursor-test-agent");
+      assert.ok(loaded, "expected agent to load");
+      assert.equal(loaded.cli, "cursor");
+      assert.equal(loaded.cursorForce, false);
+      assert.equal(loaded.cursorYolo, true);
+      assert.equal(loaded.cursorMode, "plan");
+      assert.equal(loaded.cursorSandbox, "disabled");
+    });
+  });
+
   it("loads explicit interactive flag from frontmatter", async () => {
     await withIsolatedAgentEnv(async ({ projectAgentsDir }) => {
       writeAgentFile(
@@ -1089,6 +1144,128 @@ describe("subagent discovery", () => {
   it("buildSubagentToolAllowlist returns null without an explicit tool restriction", () => {
     assert.equal(testApi.buildSubagentToolAllowlist(undefined), null);
     assert.equal(testApi.buildSubagentToolAllowlist(""), null);
+  });
+
+  it("buildClaudePermissionArgs keeps legacy bypass permissions by default", () => {
+    assert.deepEqual(testApi.buildClaudePermissionArgs(null), ["--dangerously-skip-permissions"]);
+    assert.deepEqual(testApi.buildClaudePermissionArgs({}), ["--dangerously-skip-permissions"]);
+  });
+
+  it("buildClaudePermissionArgs supports read-only Claude Code overrides", () => {
+    assert.deepEqual(
+      testApi.buildClaudePermissionArgs({
+        claudePermissionMode: "default",
+        claudeAllowedTools: "Read,Grep,Glob",
+        claudeDisallowedTools: "Bash,Edit,Write",
+      }),
+      [
+        "--permission-mode",
+        "'default'",
+        "--tools",
+        "'Read,Grep,Glob'",
+        "--disallowed-tools",
+        "'Bash,Edit,Write'",
+      ],
+    );
+  });
+
+  it("buildCursorPermissionArgs defaults to force mode", () => {
+    assert.deepEqual(testApi.buildCursorPermissionArgs(null), ["--force"]);
+    assert.deepEqual(testApi.buildCursorPermissionArgs({}), ["--force"]);
+  });
+
+  it("buildCursorPermissionArgs supports yolo and sandbox overrides", () => {
+    assert.deepEqual(
+      testApi.buildCursorPermissionArgs({
+        cursorForce: false,
+        cursorYolo: true,
+        cursorSandbox: "disabled",
+      }),
+      ["--yolo", "--sandbox", "'disabled'"],
+    );
+  });
+
+  it("buildCursorPermissionArgs supports read-only plan mode", () => {
+    assert.deepEqual(
+      testApi.buildCursorPermissionArgs({
+        cursorMode: "plan",
+        cursorForce: false,
+      }),
+      ["--mode", "'plan'"],
+    );
+  });
+
+  it("merges and removes the Cursor stop hook without touching other hooks", () => {
+    const config = {
+      version: 1,
+      hooks: {
+        stop: [{ command: "./hooks/existing.sh" }],
+        afterFileEdit: [{ command: "./hooks/format.sh" }],
+      },
+    };
+
+    const installed = testApi.ensureCursorHookConfig(config);
+    assert.deepEqual(installed.hooks.stop, [
+      { command: "./hooks/existing.sh" },
+      { command: "./hooks/pi-interactive-subagents-stop.sh", timeout: 10 },
+    ]);
+
+    const removed = testApi.removeCursorHookConfig(installed);
+    assert.deepEqual(removed, config);
+  });
+
+  it("extracts Cursor plan output from transcript before terminal UI text", () => {
+    withTempDir((dir) => {
+      const transcript = join(dir, "cursor.jsonl");
+      writeFileSync(
+        transcript,
+        [
+          JSON.stringify({
+            role: "assistant",
+            message: { content: [{ type: "text", text: "Starting exploration" }] },
+          }),
+          JSON.stringify({
+            role: "assistant",
+            message: {
+              content: [
+                { type: "text", text: "[REDACTED]" },
+                {
+                  type: "tool_use",
+                  name: "CreatePlan",
+                  input: { name: "Repo report", plan: "# Clean report\n\nFindings here." },
+                },
+              ],
+            },
+          }),
+        ].join("\n") + "\n",
+      );
+
+      assert.equal(
+        testApi.extractCursorSummaryFromTranscriptPath(transcript),
+        "# Clean report\n\nFindings here.",
+      );
+    });
+  });
+
+  it("falls back to last Cursor assistant text when no plan exists", () => {
+    withTempDir((dir) => {
+      const transcript = join(dir, "cursor.jsonl");
+      writeFileSync(
+        transcript,
+        [
+          JSON.stringify({
+            role: "assistant",
+            message: { content: [{ type: "text", text: "First message" }] },
+          }),
+          JSON.stringify({
+            role: "assistant",
+            message: { content: [{ type: "text", text: "Final summary" }] },
+          }),
+        ].join("\n") + "\n",
+      );
+
+      assert.equal(testApi.extractCursorSummaryFromTranscriptPath(transcript), "Final summary");
+    });
   });
 
   it("buildPiPromptArgs inserts separator for artifact-backed launches with skills", () => {
@@ -1840,6 +2017,33 @@ describe("subagent interruption", () => {
         error: "claude interrupt unsupported",
         id: "a1",
         name: "Worker",
+      });
+    } finally {
+      runningMap.clear();
+    }
+  });
+
+  it("delivers Cursor-backed interrupt requests", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const runningMap = testApi.runningSubagents as Map<string, any>;
+    const surfaces: string[] = [];
+    runningMap.clear();
+
+    try {
+      runningMap.set("a1", makeRunning({
+        cli: "cursor",
+        statusState: createStatusState({ source: "cursor", startTimeMs: 0 }),
+      }));
+
+      const result = testApi.handleSubagentInterrupt({ name: "Worker" }, (surface: string) => {
+        surfaces.push(surface);
+      });
+
+      assert.deepEqual(surfaces, ["pane-1"]);
+      assert.deepEqual(result.details, {
+        id: "a1",
+        name: "Worker",
+        status: "interrupt_requested",
       });
     } finally {
       runningMap.clear();


### PR DESCRIPTION
## Summary
- Add a Cursor Agent backend that launches the local Cursor Agent CLI from subagent definitions
- Mirror the Claude sentinel completion flow with temporary guarded Cursor stop hook and lease-based cleanup
- Support read-only plan/ask modes and sandbox/permission overrides via Cursor-prefixed frontmatter

## Testing
- Tested locally