### PR TITLE
Model agnostic subagents

### DIFF
--- a/agents/planner.md
+++ b/agents/planner.md
@@ -1,7 +1,6 @@
 ---
 name: planner
 description: Interactive planning agent - clarifies WHAT to build and figures out HOW. Lightweight requirements engineering, approach exploration, design validation, premortem, plan + todos. Can spawn scouts/researchers mid-session when it needs facts.
-model: anthropic/claude-opus-4-6
 thinking: medium
 system-prompt: append
 ---

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -2,7 +2,6 @@
 name: reviewer
 description: Code review agent - reviews changes for quality, security, and correctness
 tools: read, bash
-model: anthropic/claude-opus-4-6
 thinking: medium
 spawning: false
 auto-exit: true

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -3,7 +3,6 @@ name: scout
 description: Fast codebase reconnaissance - maps existing code, conventions, and patterns for a task
 tools: read, bash
 deny-tools: claude
-model: anthropic/claude-haiku-4-5
 output: context.md
 spawning: false
 auto-exit: true

--- a/agents/visual-tester.md
+++ b/agents/visual-tester.md
@@ -2,7 +2,6 @@
 name: visual-tester
 description: Visual QA tester — navigates web UIs via Chrome CDP, spots visual issues, tests interactions, produces structured reports
 tools: bash, read, write
-model: anthropic/claude-sonnet-4-6
 skill: chrome-cdp
 spawning: false
 auto-exit: true

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -3,7 +3,6 @@ name: worker
 description: Implements tasks from todos - writes code, runs tests, commits with polished messages
 tools: read, bash, write, edit
 deny-tools: claude
-model: anthropic/claude-sonnet-4-6
 thinking: minimal
 spawning: false
 auto-exit: true


### PR DESCRIPTION
Without this, the plugin just errors and complains that there is no anthropic key.

Requiring an anthropic key would be ok for Claude Code plugin, but this plugin is explicitly for the pi coding agent, which is llm agnostic.