### PR TITLE
feat(subagent): add getArgumentCompletions for agent names

### DIFF
--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { keyHint } from "@mariozechner/pi-coding-agent";
 import { Type, type Static } from "@sinclair/typebox";
-import { Box, Text, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import { type AutocompleteItem, Box, Text, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -1978,6 +1978,20 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   // /subagent command — spawn a subagent by name
   pi.registerCommand("subagent", {
     description: "Spawn a subagent: /subagent <agent> <task>",
+    getArgumentCompletions: (prefix: string): AutocompleteItem[] | null => {
+      // Only complete the agent-name argument; once the user has typed a space
+      // they are entering the freeform task portion — return null there.
+      if (prefix.includes(" ")) return null;
+      const agents = discoverAgentDefinitions();
+      const lower = prefix.toLowerCase();
+      const matches = agents
+        .filter((a) => a.name.toLowerCase().startsWith(lower))
+        .map((a) => ({
+          value: a.name,
+          label: a.description ? `${a.name} — ${a.description}` : a.name,
+        }));
+      return matches.length > 0 ? matches : null;
+    },
     handler: async (args, ctx) => {
       const trimmed = args.trim();
       if (!trimmed) {


### PR DESCRIPTION
## Summary

Pi's SDK supports `getArgumentCompletions` on `pi.registerCommand` (see `docs/extensions.md`), but the `/subagent` slash command didn't implement it — so typing `/subagent ` and pressing Tab showed no suggestions even though this extension is precisely the one that knows what agents are available.

## Change

Wire `getArgumentCompletions` to the existing `discoverAgentDefinitions()` (already used elsewhere in the file). One import added (`AutocompleteItem` from `@mariozechner/pi-tui`), one callback added to the `/subagent` command options at index.ts:1981.

Behaviour:
- Case-insensitive prefix filter on agent `name`.
- Returns `{ value, label }` items where `label` combines name + description.
- Returns `null` (per SDK contract) when the filtered list is empty.
- Returns `null` when the prefix contains a space — the user is in the freeform task-arg territory, no completion appropriate.

Scope discipline: only `pi-extension/subagents/index.ts` is touched. `/plan` and `/iterate` are untouched.

## Verification

- grep confirms exactly one usage of `getArgumentCompletions` inside the `/subagent` block (plus the import).
- No new test failures (existing `ERR_MODULE_NOT_FOUND` on `npm test` is pre-existing on `main`, unrelated to this change).
- Manually verified in a live pi session: agent names now auto-complete on Tab.

## Not changed

- `/plan` and `/iterate` — same completion gap exists there but is out of scope.
- No refactor, no dependency bumps, no agent-frontmatter changes.